### PR TITLE
add fits_movnam_hdu()

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -88,6 +88,18 @@ example which shows how to use them:
    HDUs (positive means forward), and return the same as
    :func:`fits_movabs_hdu`.
 
+.. function:: fits_movnam_hdu(f::FITSFile, extname::String, extver::Integer=0,
+                              hdu_type_int::Integer=-1)
+
+   Change the current HDU by moving to the (first) HDU which has the
+   specified extension type and EXTNAME and EXTVER keyword values (or
+   HDUNAME and HDUVER keywords). If ``extver`` is 0 (the default) then
+   the EXTVER keyword is ignored and the first HDU with a matching
+   EXTNAME (or HDUNAME) keyword will be found. If ``hdu_type_int``
+   is -1 (the default) only the extname and extver values will be used
+   to locate the correct extension. If no matching HDU is found in the
+   file, the current HDU will remain unchanged.
+
 
 Header Keyword Routines
 -----------------------


### PR DESCRIPTION
Wrap the function `fits_movnam_hdu()`.

I also threw in a small change to `show()` whereby the current HDU is indicated with an asterisk.

While implementing this I noticed that none of the statuses are getting captured in ccall. Passing the pointer `&f.status` in ccall doesn't allow the c library to update `f.status`, so `f.status` always remains 0, even when a non-zero status is returned by cfitsio. I'm going to work on fixing this in a separate PR.
