### PR TITLE
correctly capture status then forget it

### DIFF
--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -56,7 +56,7 @@ end
 
 function fits_assert_ok(status::Int32)
     if status != 0
-        throw(fits_get_errstatus(status))
+        error(fits_get_errstatus(status))
     end
 end
 


### PR DESCRIPTION
This removes the `status` field from `FITSFile`, instead making `status` a local variable in each function. In each function, an appropriate error is raised if `status != 0`, so there should be no need to keep a non-zero status in a `FITSFile` instance.

Here is an example of why keeping a non-zero status in `FITSFile`, as is the existing intended behavior (suppose the keyword "EXTNAME" does not exist in the CHDU):

``` julia
try
    extname = fits_read_keyword(f, "EXTNAME")[1]
catch
end
fits_movabs_hdu(f, i)  # <-- fails with error message about a missing keyword
```

Even though we're catching the error raised by `fits_read_keyword`, `f.status` was set to 202 anyway. When we get to `fits_movabs_hdu(f, i)`, it returns immediately because `f.status` is nonzero, and returns the error message associated with code 202.
