### PR TITLE
wrap fits_hdr2str()

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -88,8 +88,7 @@ example which shows how to use them:
    HDUs (positive means forward), and return the same as
    :func:`fits_movabs_hdu`.
 
-.. function:: fits_movnam_hdu(f::FITSFile, extname::String, extver::Integer=0,
-                              hdu_type_int::Integer=-1)
+.. function:: fits_movnam_hdu(f::FITSFile, extname::String, extver::Integer=0, hdu_type_int::Integer=-1)
 
    Change the current HDU by moving to the (first) HDU which has the
    specified extension type and EXTNAME and EXTVER keyword values (or
@@ -136,6 +135,11 @@ Header Keyword Routines
 .. function:: fits_delete_key(f::FITSFile, keyname::String)
 
    Delete the keyword named ``keyname``.
+
+.. function:: fits_hdr2str(f::FITSFile, nocomments::Bool=false)
+
+   Return the header of the CHDU as a string. If ``nocomments`` is ``true``,
+   comment cards are stripped from the output.
 
 Primary Array Routines
 ----------------------


### PR DESCRIPTION
One more function.

This is important for using a WCS library, where the WCS is initialized from a header string.

I realized that `bytestring` creates a copy, meaning that the entire header string will be copied, seemingly unnecessarily.  I don't know how to avoid this though... seems that it would require telling julia to reinterpret the `Ptr{Uint8}` as an `ASCIIString` and also to take ownership of it. It wasn't quite clear to me from the C interface docs if this is possible (or for that matter, recommended).
