### PR TITLE
Fix types

### DIFF
--- a/src/cfitsio.jl
+++ b/src/cfitsio.jl
@@ -1,5 +1,109 @@
 using Compat
 
+# functions to convert to C integer types (this could be in Julia Base module):
+for (f, T) in ((:cint,  Cint),
+               (:clong, Clong))
+    @eval begin
+        ($f)(x::$T) = x
+        ($f)(x::Integer) = convert($T, x)
+        ($f)(x::AbstractArray{$T}) = x
+        function ($f){T<:Integer}(x::AbstractArray{T})
+            y = similar(x, $T)
+            i = 1
+            for e in x
+                y[i] = convert($T, e)
+                i += 1
+            end
+            y
+        end
+    end
+end
+
+# The following table gives the correspondances between CFITSIO "types",
+# the BITPIX keyword and Julia types.
+#
+#     -------------------------------------------------
+#     CODE  CFISTIO         Julia     Comments
+#     -------------------------------------------------
+#           int             Cint
+#           long            Clong
+#           LONGLONG        Int64     64-bit integer
+#     -------------------------------------------------
+#     -------- FITS BITPIX ----------------------------
+#        8  BYTE_IMG        Uint8
+#       16  SHORT_IMG       Int16
+#       32  LONG_IMG        Int32
+#       64  LONGLONG_IMG    Int64
+#      -32  FLOAT_IMG       Float32
+#      -64  DOUBLE_IMG      Float64
+#      -------- cfitsio "aliases" ---------------------
+#       10  SBYTE_IMG       Int8     written as: BITPIX = 8, BSCALE = 1, BZERO = -128
+#       20  USHORT_IMG      Uint16   written as: BITPIX = 16, BSCALE = 1, BZERO = 32768
+#       40  LONG_IMG        Uint32   written as: BITPIX = 32, BSCALE = 1, BZERO = 2147483648
+#     -------------------------------------------------
+#     -------- FITS TABLE DATA TYPES ------------------
+#        1  TBIT
+#       11  TBYTE           Cuchar = Uint8
+#       12  TSBYTE          Cchar = Int8
+#       14  TLOGICAL        Bool
+#       16  TSTRING         ASCIIString
+#       20  TUSHORT         Cushort
+#       21  TSHORT          Cshort
+#       30  TUINT           Cuint
+#       31  TINT            Cint
+#       40  TULONG          Culong
+#       41  TLONG           Clong
+#       42  TFLOAT          Cfloat
+#       81  TLONGLONG       Int64
+#       82  TDOUBLE         Cdouble
+#       83  TCOMPLEX        Complex{Cfloat}
+#      163  TDBLCOMPLEX     Complex{Cdouble}
+#     -------------------------------------------------
+#
+
+const bitpix_to_type = Dict{Cint, DataType}()
+for (T, code) in ((Uint8,     8), # BYTE_IMG
+                  (Int16,    16), # SHORT_IMG
+                  (Int32,    32), # LONG_IMG
+                  (Int64,    64), # LONGLONG_IMG
+                  (Float32, -32), # FLOAT_IMG
+                  (Float64, -64), # DOUBLE_IMG
+                  (Int8,     10), # SBYTE_IMG
+                  (Uint16,   20), # USHORT_IMG
+                  (Uint32,   40)) # ULONG_IMG
+    local value = cint(code)
+    @eval begin
+        bitpix_to_type[$value] = $T
+        _cfitsio_bitpix(::Type{$T}) = $value
+    end
+end
+
+for (T, code) in ((Uint8,       11),
+                  (Int8,        12),
+                  (Bool,        14),
+                  (String,      16),
+                  (Cushort,     20),
+                  (Cshort,      21),
+                  (Cuint,       30),
+                  (Cint,        31),
+                  (Culong,      40),
+                  (Clong,       41),
+                  (Float32,     42),
+                  (Int64,       81),
+                  (Float64,     82),
+                  (Complex64,   83),
+                  (Complex128, 163))
+    local value = cint(code)
+    @eval begin
+        if $T == String
+            _cfitsio_datatype{T<:$T}(::Type{T}) = $value
+        else
+            _cfitsio_datatype(::Type{$T}) = $value
+        end
+    end
+end
+
+
 type FITSFile
     ptr::Ptr{Void}
 
@@ -16,54 +120,17 @@ function fits_assert_open(f::FITSFile)
     end
 end
 
-function fits_get_errstatus(status::Int32)
+function fits_get_errstatus(status::Cint)
     msg = Array(Uint8, 31)
-    ccall((:ffgerr,libcfitsio), Void, (Int32,Ptr{Uint8}), status, msg)
+    ccall((:ffgerr,libcfitsio), Void, (Cint,Ptr{Uint8}), status, msg)
     bytestring(convert(Ptr{Uint8},msg))
 end
 
-function fits_assert_ok(status::Int32)
+function fits_assert_ok(status::Cint)
     if status != 0
         error(fits_get_errstatus(status))
     end
 end
-
-# constants
-
-_cfitsio_bitpix(::Type{Uint8}) = int32(8)  # BYTE_IMG
-_cfitsio_bitpix(::Type{Int16}) = int32(16) # SHORT_IMG
-_cfitsio_bitpix(::Type{Int32}) = int32(32) # LONG_IMG
-_cfitsio_bitpix(::Type{Int64}) = int32(64) # LONGLONG_IMG
-_cfitsio_bitpix(::Type{Float32}) = int32(-32) # FLOAT_IMG
-_cfitsio_bitpix(::Type{Float64}) = int32(-64) # DOUBLE_IMG
-
-# cfitsio "aliases":
-# SBYTE_IMG => BITPIX = 8, BSCALE = 1, BZERO = -128
-# USHORT_IMG => BITPIX = 16, BSCALE = 1, BZERO = 32768
-# ULONG_IMG => BITPIX = 32, BSCALE = 1, BZERO = 2147483648
-_cfitsio_bitpix(::Type{Int8}) = int32(10)  # SBYTE_IMG
-_cfitsio_bitpix(::Type{Uint16}) = int32(20) # USHORT_IMG
-_cfitsio_bitpix(::Type{Uint32}) = int32(40) # ULONG_IMG
-
-const bitpix_to_type = @compat Dict(int32(8)=>Uint8, int32(16)=>Int16,
-                        int32(32)=>Int32, int32(64)=>Int64,
-                        int32(-32)=>Float32, int32(-64)=>Float64,
-                        int32(10)=>Int8, int32(20)=>Uint16,
-                        int32(40)=>Uint32)
-
-_cfitsio_datatype(::Type{Uint8})      = int32(11)
-_cfitsio_datatype(::Type{Int8})       = int32(12)
-_cfitsio_datatype(::Type{Bool})       = int32(14)
-_cfitsio_datatype{T<:String}(::Type{T}) = int32(16)
-_cfitsio_datatype(::Type{Uint16})     = int32(20)
-_cfitsio_datatype(::Type{Int16})      = int32(21)
-_cfitsio_datatype(::Type{Uint32})     = int32(30)
-_cfitsio_datatype(::Type{Int32})      = int32(31)
-_cfitsio_datatype(::Type{Float32})    = int32(42)
-_cfitsio_datatype(::Type{Int64})      = int32(81)
-_cfitsio_datatype(::Type{Float64})    = int32(82)
-_cfitsio_datatype(::Type{Complex64})  = int32(83)
-_cfitsio_datatype(::Type{Complex128}) = int32(163)
 
 function hdu_int_to_type(hdu_type_int)
     if hdu_type_int == 0
@@ -77,7 +144,7 @@ function hdu_int_to_type(hdu_type_int)
     :unknown
 end
 
-const mode_strs = @compat Dict(int32(0)=>"READONLY", int32(1)=>"READWRITE")
+const mode_strs = @compat Dict(cint(0)=>"READONLY", cint(1)=>"READWRITE")
 
 
 # General-purpose functions
@@ -86,14 +153,14 @@ for (a,b,T) in ((:fits_file_mode,     "ffflmd",  :Cint),
                 (:fits_get_num_cols,  "ffgncl",  :Cint),
                 (:fits_get_num_hdus,  "ffthdu",  :Cint),
                 (:fits_get_num_rows,  "ffgnrw",  :Clong),
-                (:fits_get_num_rowsll,"ffgnrwll",:Clonglong),
-                (:fits_get_rowsize,   "ffgrsz",  :Cint))
+                (:fits_get_num_rowsll,"ffgnrwll",:Int64),
+                (:fits_get_rowsize,   "ffgrsz",  :Clong))
     @eval begin
         function ($a)(f::FITSFile)
             result = $T[0]
-            status = Int32[0]
-            ccall(($b,libcfitsio), Int32,
-                  (Ptr{Void}, Ptr{$T}, Ptr{Int32}),
+            status = Cint[0]
+            ccall(($b,libcfitsio), Cint,
+                  (Ptr{Void}, Ptr{$T}, Ptr{Cint}),
                   f.ptr, result, status)
             fits_assert_ok(status[1])
             result[1]
@@ -105,9 +172,9 @@ end
 
 function fits_create_file(filename::String)
     ptr = Array(Ptr{Void}, 1)
-    status = Int32[0]
+    status = Cint[0]
     ccall((:ffinit,libcfitsio),
-        Int32, (Ptr{Ptr{Void}},Ptr{Uint8},Ptr{Int32}),
+        Cint, (Ptr{Ptr{Void}},Ptr{Uint8},Ptr{Cint}),
         ptr, bytestring(filename), status)
     fits_assert_ok(status[1])
     FITSFile(ptr[1])
@@ -120,11 +187,11 @@ for (a,b) in ((:fits_open_data, "ffdopn"),
               (:fits_open_image,"ffiopn"),
               (:fits_open_table,"fftopn"))
     @eval begin
-        function ($a)(filename::String, mode::Int=0)
+        function ($a)(filename::String, mode::Integer=0)
             ptr = Array(Ptr{Void}, 1)
-            status = Int32[0]
-            ccall(($b,libcfitsio), Int32,
-                  (Ptr{Ptr{Void}},Ptr{Uint8},Int32,Ptr{Int32}),
+            status = Cint[0]
+            ccall(($b,libcfitsio), Cint,
+                  (Ptr{Ptr{Void}},Ptr{Uint8},Cint,Ptr{Cint}),
                   ptr, bytestring(filename), mode, status)
             fits_assert_ok(status[1])
             FITSFile(ptr[1])
@@ -136,13 +203,13 @@ for (a,b) in ((:fits_close_file, "ffclos"),
               (:fits_delete_file,"ffdelt"))
     @eval begin
         function ($a)(f::FITSFile)
-            
+
             # fits_close_file() is called during garbage collection, but file
             # may already be closed by user, so we need to check if it is open.
             if f.ptr != C_NULL
-                status = Int32[0]
-                ccall(($b,libcfitsio), Int32,
-                      (Ptr{Void},Ptr{Int32}),
+                status = Cint[0]
+                ccall(($b,libcfitsio), Cint,
+                      (Ptr{Void},Ptr{Cint}),
                       f.ptr, status)
                 fits_assert_ok(status[1])
                 f.ptr = C_NULL
@@ -155,9 +222,9 @@ close(f::FITSFile) = fits_close_file(f)
 
 function fits_file_name(f::FITSFile)
     value = Array(Uint8, 1025)
-    status = Int32[0]
-    ccall((:ffflnm,libcfitsio), Int32,
-          (Ptr{Void},Ptr{Uint8},Ptr{Int32}),
+    status = Cint[0]
+    ccall((:ffflnm,libcfitsio), Cint,
+          (Ptr{Void},Ptr{Uint8},Ptr{Cint}),
           f.ptr, value, status)
     fits_assert_ok(status[1])
     bytestring(convert(Ptr{Uint8}, value))
@@ -166,11 +233,11 @@ end
 # header keywords
 
 function fits_get_hdrspace(f::FITSFile)
-    keysexist = Int32[0]
-    morekeys = Int32[0]
-    status = Int32[0]
-    ccall((:ffghsp,libcfitsio), Int32,
-        (Ptr{Void},Ptr{Int32},Ptr{Int32},Ptr{Int32}),
+    keysexist = Cint[0]
+    morekeys = Cint[0]
+    status = Cint[0]
+    ccall((:ffghsp,libcfitsio), Cint,
+        (Ptr{Void},Ptr{Cint},Ptr{Cint},Ptr{Cint}),
         f.ptr, keysexist, morekeys, status)
     fits_assert_ok(status[1])
     (keysexist[1], morekeys[1])
@@ -179,32 +246,32 @@ end
 function fits_read_keyword(f::FITSFile, keyname::String)
     value = Array(Uint8, 71)
     comment = Array(Uint8, 71)
-    status = Int32[0]
-    ccall((:ffgkey,libcfitsio), Int32,
-        (Ptr{Void},Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},Ptr{Int32}),
+    status = Cint[0]
+    ccall((:ffgkey,libcfitsio), Cint,
+        (Ptr{Void},Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},Ptr{Cint}),
         f.ptr, bytestring(keyname), value, comment, status)
     fits_assert_ok(status[1])
     bytestring(convert(Ptr{Uint8},value)),
     bytestring(convert(Ptr{Uint8},comment))
 end
 
-function fits_read_record(f::FITSFile, keynum::Int)
+function fits_read_record(f::FITSFile, keynum::Integer)
     card = Array(Uint8, 81)
-    status = Int32[0]
-    ccall((:ffgrec,libcfitsio), Int32,
-        (Ptr{Void},Int32,Ptr{Uint8},Ptr{Int32}),
+    status = Cint[0]
+    ccall((:ffgrec,libcfitsio), Cint,
+        (Ptr{Void},Cint,Ptr{Uint8},Ptr{Cint}),
         f.ptr, keynum, card, status)
     fits_assert_ok(status[1])
     bytestring(convert(Ptr{Uint8},card))
 end
 
-function fits_read_keyn(f::FITSFile, keynum::Int)
+function fits_read_keyn(f::FITSFile, keynum::Integer)
     keyname = Array(Uint8, 9)
     value = Array(Uint8, 71)
     comment = Array(Uint8, 71)
-    status = Int32[0]
-    ccall((:ffgkyn,libcfitsio), Int32,
-        (Ptr{Void},Int32,Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},Ptr{Int32}),
+    status = Cint[0]
+    ccall((:ffgkyn,libcfitsio), Cint,
+        (Ptr{Void},Cint,Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},Ptr{Cint}),
         f.ptr, keynum, keyname, value, comment, status)
     fits_assert_ok(status[1])
     bytestring(convert(Ptr{Uint8},keyname)),
@@ -215,10 +282,10 @@ end
 function fits_write_key(f::FITSFile, keyname::String,
                         value::Union(FloatingPoint,String), comment::String)
     cvalue = isa(value,String) ?  bytestring(value) :
-             isa(value,Bool) ? [int32(value)] : [value]
-    status = Int32[0]
-    ccall((:ffpky,libcfitsio), Int32,
-        (Ptr{Void},Int32,Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},Ptr{Int32}),
+             isa(value,Bool) ? [cint(value)] : [value]
+    status = Cint[0]
+    ccall((:ffpky,libcfitsio), Cint,
+        (Ptr{Void},Cint,Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},Ptr{Cint}),
         f.ptr, _cfitsio_datatype(typeof(value)), bytestring(keyname),
         cvalue, bytestring(comment), status)
     fits_assert_ok(status[1])
@@ -241,7 +308,7 @@ end
 # update key: if already present, update it, otherwise add it.
 for (a,T,S) in (("ffukys", :ASCIIString, :(Ptr{Uint8})),
                 ("ffukyl", :Bool,        :Cint),
-                ("ffukyj", :Integer,     :Clonglong))
+                ("ffukyj", :Integer,     :Int64))
     @eval begin
         function fits_update_key(f::FITSFile, key::ASCIIString, value::$T,
                                  comment::Union(ASCIIString, Ptr{Void})=C_NULL)
@@ -263,42 +330,42 @@ function fits_update_key(f::FITSFile, key::ASCIIString, value::FloatingPoint,
 end
 
 function fits_write_record(f::FITSFile, card::String)
-    status = Int32[0]
-    ccall((:ffprec,libcfitsio), Int32,
-        (Ptr{Void},Ptr{Uint8},Ptr{Int32}),
+    status = Cint[0]
+    ccall((:ffprec,libcfitsio), Cint,
+        (Ptr{Void},Ptr{Uint8},Ptr{Cint}),
         f.ptr, bytestring(card), status)
     fits_assert_ok(status[1])
 end
 
-function fits_delete_record(f::FITSFile, keynum::Int)
-    status = Int32[0]
-    ccall((:ffdrec,libcfitsio), Int32,
-        (Ptr{Void},Int32,Ptr{Int32}),
+function fits_delete_record(f::FITSFile, keynum::Integer)
+    status = Cint[0]
+    ccall((:ffdrec,libcfitsio), Cint,
+        (Ptr{Void},Cint,Ptr{Cint}),
         f.ptr, keynum, status)
     fits_assert_ok(status[1])
 end
 
 function fits_delete_key(f::FITSFile, keyname::String)
-    status = Int32[0]
-    ccall((:ffdkey,libcfitsio), Int32,
-        (Ptr{Void},Ptr{Uint8},Ptr{Int32}),
+    status = Cint[0]
+    ccall((:ffdkey,libcfitsio), Cint,
+        (Ptr{Void},Ptr{Uint8},Ptr{Cint}),
         f.ptr, bytestring(keyname), status)
     fits_assert_ok(status[1])
 end
 
 function fits_hdr2str(f::FITSFile, nocomments::Bool=false)
-    status = Int32[0]
+    status = Cint[0]
     header = Array(Ptr{Uint8}, 1)
-    nkeys = Int32[0]
-    ccall((:ffhdr2str, libcfitsio), Ptr{Ptr{Uint8}},
-          (Ptr{Void},Int32, Ptr{Ptr{Uint8}}, Int32,
-           Ptr{Ptr{Uint8}}, Ptr{Int32}, Ptr{Int32}),
+    nkeys = Cint[0]
+    ccall((:ffhdr2str, libcfitsio), Cint,
+          (Ptr{Void}, Cint, Ptr{Ptr{Uint8}}, Cint,
+           Ptr{Ptr{Uint8}}, Ptr{Cint}, Ptr{Cint}),
           f.ptr, nocomments, &C_NULL, 0, header, nkeys, status)
     result = bytestring(header[1])
 
     # free header pointer allocated by cfitsio (result is a copy)
-    ccall((:fffree, libcfitsio), Ptr{Int32},
-          (Ptr{Uint8}, Ptr{Int32}),
+    ccall((:fffree, libcfitsio), Ptr{Cint},
+          (Ptr{Uint8}, Ptr{Cint}),
           header[1], status)
     fits_assert_ok(status[1])
     result
@@ -310,10 +377,10 @@ for (a,b) in ((:fits_movabs_hdu,"ffmahd"),
               (:fits_movrel_hdu,"ffmrhd"))
     @eval begin
         function ($a)(f::FITSFile, hduNum::Integer)
-            hdu_type = Int32[0]
-            status = Int32[0]
-            ccall(($b,libcfitsio), Int32,
-                  (Ptr{Void}, Int32, Ptr{Int32}, Ptr{Int32}),
+            hdu_type = Cint[0]
+            status = Cint[0]
+            ccall(($b,libcfitsio), Cint,
+                  (Ptr{Void}, Cint, Ptr{Cint}, Ptr{Cint}),
                   f.ptr, hduNum, hdu_type, status)
             fits_assert_ok(status[1])
             hdu_int_to_type(hdu_type[1])
@@ -323,26 +390,26 @@ end
 
 function fits_movnam_hdu(f::FITSFile, extname::String, extver::Integer=0,
                          hdu_type::Integer=-1)
-    status = Int32[0]
-    ccall((:ffmnhd,libcfitsio), Int32,
-          (Ptr{Void}, Int32, Ptr{Uint8}, Int32, Ptr{Int32}),
-          f.ptr, int32(hdu_type), bytestring(extname), int32(extver), status)
+    status = Cint[0]
+    ccall((:ffmnhd,libcfitsio), Cint,
+          (Ptr{Void}, Cint, Ptr{Uint8}, Cint, Ptr{Cint}),
+          f.ptr, hdu_type, bytestring(extname), extver, status)
     fits_assert_ok(status[1])
 end
 
 function fits_get_hdu_num(f::FITSFile)
-    hdunum = Int32[0]
-    ccall((:ffghdn,libcfitsio), Int32,
-          (Ptr{Void},Ptr{Int32}),
+    hdunum = Cint[0]
+    ccall((:ffghdn,libcfitsio), Cint,
+          (Ptr{Void}, Ptr{Cint}),
           f.ptr, hdunum)
     hdunum[1]
 end
 
 function fits_get_hdu_type(f::FITSFile)
-    hdutype = Int32[0]
-    status = Int32[0]
-    ccall((:ffghdt, libcfitsio), Int32,
-          (Ptr{Void}, Ptr{Int32}, Ptr{Int32}),
+    hdutype = Cint[0]
+    status = Cint[0]
+    ccall((:ffghdt, libcfitsio), Cint,
+          (Ptr{Void}, Ptr{Cint}, Ptr{Cint}),
           f.ptr, hdutype, status)
     fits_assert_ok(status[1])
     hdu_int_to_type(hdutype[1])
@@ -350,105 +417,89 @@ end
 
 # primary array or IMAGE extension
 
-function fits_get_img_type(f::FITSFile)
-    bitpix = Int32[0]
-    status = Int32[0]
-    ccall((:ffgidt,libcfitsio), Int32,
-        (Ptr{Void},Ptr{Int32},Ptr{Int32}),
-        f.ptr, bitpix, status)
-    fits_assert_ok(status[1])
-    bitpix[1]
-end
-
-function fits_get_img_equivtype(f::FITSFile)
-    bitpix = Int32[0]
-    status = Int32[0]
-    ccall((:ffgiet,libcfitsio), Int32,
-        (Ptr{Void},Ptr{Int32},Ptr{Int32}),
-        f.ptr, bitpix, status)
-    fits_assert_ok(status[1])
-    bitpix[1]
-end
-
-function fits_get_img_dim(f::FITSFile)
-    ndim = Int32[0]
-    status = Int32[0]
-    ccall((:ffgidm,libcfitsio), Int32,
-        (Ptr{Void},Ptr{Int32},Ptr{Int32}),
-        f.ptr, ndim, status)
-    fits_assert_ok(status[1])
-    ndim[1]
+for (a, b) in ((:fits_get_img_type,      "ffgidt"),
+               (:fits_get_img_equivtype, "ffgiet"),
+               (:fits_get_img_dim,       "ffgidm"))
+    @eval function ($a)(f::FITSFile)
+        result = Cint[0]
+        status = Cint[0]
+        ccall(($b, libcfitsio), Cint, (Ptr{Void}, Ptr{Cint}, Ptr{Cint}),
+              f.ptr, result, status)
+        fits_assert_ok(status[1])
+        result[1]
+    end
 end
 
 function fits_get_img_size(f::FITSFile)
     ndim = fits_get_img_dim(f)
-    naxes = zeros(Int, ndim)
-    status = Int32[0]
-    ccall((:ffgisz,libcfitsio), Int32,
-        (Ptr{Void},Int32,Ptr{Int},Ptr{Int32}),
+    naxes = Array(Clong, ndim)
+    status = Cint[0]
+    ccall((:ffgisz, libcfitsio), Cint,
+        (Ptr{Void}, Cint, Ptr{Clong}, Ptr{Cint}),
         f.ptr, ndim, naxes, status)
     fits_assert_ok(status[1])
     naxes
 end
 
-function fits_create_img(f::FITSFile, t::Type, naxes::Vector{Int})
-    status = Int32[0]
-    ccall((:ffcrim,libcfitsio), Int32,
-        (Ptr{Void},Int32,Int32,Ptr{Int},Ptr{Int32}),
-        f.ptr, _cfitsio_bitpix(t), length(naxes), naxes, status)
+function fits_create_img{S<:Integer}(f::FITSFile, t::Type, naxes::Vector{S})
+    status = Cint[0]
+    ccall((:ffcrimll, libcfitsio), Cint,
+          (Ptr{Void}, Cint, Cint, Ptr{Int64}, Ptr{Cint}),
+          f.ptr, _cfitsio_bitpix(t), length(naxes), int64(naxes), status)
     fits_assert_ok(status[1])
 end
 
-function fits_write_pix{T}(f::FITSFile, fpixel::Vector{Int}, nelements::Int, data::Array{T})
-    status = Int32[0]
-    ccall((:ffppx,libcfitsio), Int32,
-        (Ptr{Void},Int32,Ptr{Int},Int,Ptr{Void},Ptr{Int32}),
-        f.ptr, _cfitsio_datatype(T), fpixel, nelements, data, status)
+function fits_write_pix{S<:Integer,T}(f::FITSFile, fpixel::Vector{S},
+                                      nelements::Integer, data::Array{T})
+    status = Cint[0]
+    ccall((:ffppxll, libcfitsio), Cint,
+        (Ptr{Void}, Cint, Ptr{Int64}, Int64, Ptr{Void}, Ptr{Cint}),
+        f.ptr, _cfitsio_datatype(T), int64(fpixel), nelements, data, status)
     fits_assert_ok(status[1])
 end
-fits_write_pix(f::FITSFile, data::Array) = fits_write_pix(f, ones(Int,length(size(data))), length(data), data)
+fits_write_pix(f::FITSFile, data::Array) = fits_write_pix(f, ones(Int64, length(size(data))), length(data), data)
 
-function fits_read_pix{T}(f::FITSFile, fpixel::Vector{Int}, nelements::Int, nullval::T, data::Array{T})
-    anynull = Int32[0]
-    status = Int32[0]
-    ccall((:ffgpxv,libcfitsio), Int32,
-        (Ptr{Void},Int32,Ptr{Int},Int,Ptr{Void},Ptr{Void},Ptr{Int32},Ptr{Int32}),
-        f.ptr, _cfitsio_datatype(T), fpixel, nelements, &nullval, data, anynull, status)
+function fits_read_pix{S<:Integer,T}(f::FITSFile, fpixel::Vector{S}, nelements::Int, nullval::T, data::Array{T})
+    anynull = Cint[0]
+    status = Cint[0]
+    ccall((:ffgpxv,libcfitsio), Cint,
+          (Ptr{Void},Cint,Ptr{Clong},Int64,Ptr{Void},Ptr{Void},Ptr{Cint},Ptr{Cint}),
+          f.ptr, _cfitsio_datatype(T), int64(fpixel), nelements, &nullval, data, anynull, status)
     fits_assert_ok(status[1])
     anynull[1]
 end
-function fits_read_pix{T}(f::FITSFile, fpixel::Vector{Int}, nelements::Int, data::Array{T})
-    anynull = Int32[0]
-    status = Int32[0]
-    ccall((:ffgpxv,libcfitsio), Int32,
-        (Ptr{Void},Int32,Ptr{Int},Int,Ptr{Void},Ptr{Void},Ptr{Int32},Ptr{Int32}),
-        f.ptr, _cfitsio_datatype(T), fpixel, nelements, C_NULL, data, anynull, status)
+function fits_read_pix{S<:Integer,T}(f::FITSFile, fpixel::Vector{S}, nelements::Int, data::Array{T})
+    anynull = Cint[0]
+    status = Cint[0]
+    ccall((:ffgpxv,libcfitsio), Cint,
+          (Ptr{Void},Cint,Ptr{Clong},Int64,Ptr{Void},Ptr{Void},Ptr{Cint},Ptr{Cint}),
+          f.ptr, _cfitsio_datatype(T), int64(fpixel), nelements, C_NULL, data, anynull, status)
     fits_assert_ok(status[1])
     anynull[1]
 end
-fits_read_pix(f::FITSFile, data::Array) = fits_read_pix(f, ones(Int,length(size(data))), length(data), data)
+fits_read_pix(f::FITSFile, data::Array) = fits_read_pix(f, ones(Int64,length(size(data))), length(data), data)
 
-function fits_read_subset{T}(f::FITSFile,
-                             fpixel::Vector{Clong},
-                             lpixel::Vector{Clong},
-                             inc::Vector{Clong},
-                             data::Array{T})
+function fits_read_subset{S1<:Integer,S2<:Integer,S3<:Integer,T}(f::FITSFile,
+                                                                 fpixel::Vector{S1},
+                                                                 lpixel::Vector{S2},
+                                                                 inc::Vector{S3},
+                                                                 data::Array{T})
     anynull = Cint[0]
     status = Cint[0]
     ccall((:ffgsv,libcfitsio), Cint,
-          (Ptr{Void},Cint,Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Void},Ptr{Void},
-           Ptr{Cint},Ptr{Cint}),
-          f.ptr, _cfitsio_datatype(T), fpixel, lpixel, inc, C_NULL, data,
-          anynull, status)
+          (Ptr{Void},Cint,Ptr{Clong},Ptr{Clong},Ptr{Clong},Ptr{Void},Ptr{Void},Ptr{Cint},Ptr{Cint}),
+          f.ptr, _cfitsio_datatype(T),
+          clong(fpixel), clong(lpixel), clong(inc),
+          C_NULL, data, anynull, status)
     fits_assert_ok(status[1])
     anynull[1]
 end
 
 function fits_copy_image_section(fin::FITSFile, fout::FITSFile,
                                  section::String)
-    status = Int32[0]
-    ccall((:fits_copy_image_section,libcfitsio), Int32,
-          (Ptr{Void}, Ptr{Void}, Ptr{Uint8}, Ptr{Int32}),
+    status = Cint[0]
+    ccall((:fits_copy_image_section,libcfitsio), Cint,
+          (Ptr{Void}, Ptr{Void}, Ptr{Uint8}, Ptr{Cint}),
           fin.ptr, fout.ptr, bytestring(section), status)
     fits_assert_ok(status[1])
 end
@@ -468,13 +519,13 @@ for (a,b) in ((:fits_create_binary_tbl, 2),
             ttype = map((x) -> pointer(x[1].data), coldefs)
             tform = map((x) -> pointer(x[2].data), coldefs)
             tunit = map((x) -> pointer(x[3].data), coldefs)
-            status = Int32[0]
+            status = Cint[0]
 
-            ccall(("ffcrtb", libcfitsio), Int32,
-                  (Ptr{Void}, Int32, Int64, Int32,
+            ccall(("ffcrtb", libcfitsio), Cint,
+                  (Ptr{Void}, Cint, Int64, Cint,
                    Ptr{Ptr{Uint8}}, Ptr{Ptr{Uint8}},
-                   Ptr{Ptr{Uint8}}, Ptr{Uint8}, Ptr{Int32}),
-                  f.ptr, $b, convert(Int32, numrows), ntype,
+                   Ptr{Ptr{Uint8}}, Ptr{Uint8}, Ptr{Cint}),
+                  f.ptr, $b, numrows, ntype,
                   ttype, tform, tunit, bytestring(extname),
                   status)
             fits_assert_ok(status[1])
@@ -483,14 +534,14 @@ for (a,b) in ((:fits_create_binary_tbl, 2),
 end
 
 function fits_get_col_repeat(f::FITSFile, colnum::Integer)
-    typecode = Int32[0]
+    typecode = Cint[0]
     repeat = Int64[0]
     width = Int64[0]
-    status = Int32[0]
+    status = Cint[0]
 
-    ccall((:ffgtclll, libcfitsio), Int32,
-          (Ptr{Void}, Int32, Ptr{Int32}, Ptr{Int64}, Ptr{Int64}, Ptr{Int32}),
-          f.ptr, convert(Int32, colnum), typecode, repeat, width, status)
+    ccall((:ffgtclll, libcfitsio), Cint,
+          (Ptr{Void}, Cint, Ptr{Cint}, Ptr{Int64}, Ptr{Int64}, Ptr{Cint}),
+          f.ptr, colnum, typecode, repeat, width, status)
 
     (repeat[1], width[1])
 end
@@ -502,12 +553,8 @@ function fits_read_col{T}(f::FITSFile,
                           firstelem::Integer,
                           data::Array{T})
 
-    anynull = Int32[0]
-    status = Int32[0]
-
-    firstrow64 = convert(Int64, firstrow)
-    firstelem64 = convert(Int64, firstelem)
-    nelements64 = convert(Int64, length(data))
+    anynull = Cint[0]
+    status = Cint[0]
 
     if isa(T, Type{String}) || isa(T, Type{ASCIIString})
 
@@ -519,11 +566,10 @@ function fits_read_col{T}(f::FITSFile,
             data[i] = repeat(" ", repcount)
         end
 
-        ccall((:ffgcvs, libcfitsio), Int32,
-              (Ptr{Void}, Int32, Int64, Int64, Int64,
-               Ptr{Uint8}, Ptr{Ptr{Uint8}}, Ptr{Int32}, Ptr{Int32}),
-              f.ptr, convert(Int32, colnum),
-              firstrow64, firstelem64, nelements64,
+        ccall((:ffgcvs, libcfitsio), Cint,
+              (Ptr{Void}, Cint, Int64, Int64, Int64,
+               Ptr{Uint8}, Ptr{Ptr{Uint8}}, Ptr{Cint}, Ptr{Cint}),
+              f.ptr, colnum, firstrow, firstelem, nelements,
               "", data, anynull, status)
 
         # Truncate the strings to the first NULL character (if present)
@@ -536,11 +582,11 @@ function fits_read_col{T}(f::FITSFile,
 
     else
 
-        ccall((:ffgcv,libcfitsio), Int32,
-              (Ptr{Void}, Int32, Int32, Int64, Int64, Int64,
-               Ptr{T}, Ptr{T}, Ptr{Int32}, Ptr{Int32}),
-              f.ptr, _cfitsio_datatype(T), convert(Int32, colnum),
-              firstrow64, firstelem64, nelements64,
+       ccall((:ffgcv,libcfitsio), Cint,
+              (Ptr{Void}, Cint, Cint, Int64, Int64, Int64,
+               Ptr{T}, Ptr{T}, Ptr{Cint}, Ptr{Cint}),
+              f.ptr, _cfitsio_datatype(T), colnum,
+              firstrow, firstelem, nelements,
               T[0], data, anynull, status)
 
     end
@@ -556,27 +602,23 @@ function fits_write_col{T}(f::FITSFile,
                            firstelem::Integer,
                            data::Array{T})
 
-    firstrow64 = convert(Int64, firstrow)
-    firstelem64 = convert(Int64, firstelem)
-    nelements64 = convert(Int64, length(data))
-    status = Int32[0]
+    status = Cint[0]
 
     if  isa(T, Type{String}) || isa(T, Type{ASCIIString})
 
-        ccall((:ffpcls, libcfitsio), Int32,
-              (Ptr{Void}, Int32, Int64, Int64, Int64,
-               Ptr{Ptr{Uint8}}, Ptr{Int32}),
-              f.ptr, convert(Int32, colnum),
-              firstrow64, firstelem64, nelements64,
+        ccall((:ffpcls, libcfitsio), Cint,
+              (Ptr{Void}, Cint, Int64, Int64, Int64,
+               Ptr{Ptr{Uint8}}, Ptr{Cint}),
+              f.ptr, colnum, firstrow, firstelem, nelements,
               data, status)
 
     else
 
-        ccall((:ffpcl,libcfitsio), Int32,
-              (Ptr{Void}, Int32, Int32, Int64, Int64, Int64,
-               Ptr{T}, Ptr{Int32}),
-              f.ptr, _cfitsio_datatype(T), convert(Int32, colnum),
-              firstrow64, firstelem64, nelements64,
+        ccall((:ffpcl, libcfitsio), Cint,
+              (Ptr{Void}, Cint, Cint, Int64, Int64, Int64,
+               Ptr{T}, Ptr{Cint}),
+              f.ptr, _cfitsio_datatype(T), colnum,
+              firstrow, firstelem, nelements,
               data, status)
 
     end
@@ -589,13 +631,10 @@ for (a,b) in ((:fits_insert_rows, "ffirow"),
               (:fits_delete_rows, "ffdrow"))
     @eval begin
         function ($a)(f::FITSFile, firstrow::Integer, nrows::Integer)
-            firstrow64 = convert(Int64, firstrow)
-            nrows64 = convert(Int64, nrows)
-            status = Int32[0]
-
-            ccall(($b,libcfitsio), Int32,
-                  (Ptr{Void}, Int64, Int64, Ptr{Int32}),
-                  f.ptr, firstrow64, nrows64, status)
+            status = Cint[0]
+            ccall(($b,libcfitsio), Cint,
+                  (Ptr{Void}, Int64, Int64, Ptr{Cint}),
+                  f.ptr, firstrow, nrows, status)
             fits_assert_ok(status[1])
         end
     end


### PR DESCRIPTION
* fix integer types (`Int32` --> `Cint`) and double check the prototypes in `fitsio.h` header
* fix wrong type in `fits_get_rowsize/ffgrsz`
* `ffhdr2str` returns a `Cint` not a `Ptr{Ptr{Uint8}}`
* `fits_get_img_size/ffgisz` and `fits_create_img/ffcrim`: argument `naxes` is an array of long's
* use `ffcrimll` for `fits_create_img` and `ffppxll` for `fits_write_pix` instead of `ffcrim` and `ffppx` to let the user call these methods with any vector of integers (and save him/her the bothering of doing any conversion)
* in `fits_read_col` and `fits_write_col` no needs to convert to `Int64`, this is automatically done by `ccall`
* enlarge the accepted types for arguments of the methods (e.g. `keynum::Int` --> `keynum::Integer` in fits_read_record), `ccall` does the conversion
* use `@eval` macro to create data type tables and related methods, also added the table summarizing the assumptions about what types should be used (for future reference, maybe it can be in the documentation instead) missing table types 40 and 41 were added (for C `unsigned long` and C `long`) for now some methods may override another one (but this is is harmful, can be avoided later when building the dictionary of FITS table type code to Julia types which is needed to read table columns)