### PR TITLE
emit warnings for deprecated functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,16 @@
+v0.6.0 (unreleased)
+===================
+
+## Deprecations in low-level c-style interface
+
+- `fits_get_col_repeat` deprecated. Use `fits_get_coltype`, which
+  returns the column typecode in addition to width and repeat values.
+
+- Methods of `fits_read_col` and `fits_write_col` specifying the type
+  explicitly are deprecated because the type is redundant. Simply
+  remove the explicit type argument.
+
+## Internal
+
+- Cleanup and correction of type specifications (e.g., `Cint` in place
+  of `Int32`, `ASCIIString` in place of `String`)

--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -72,5 +72,6 @@ end
 
 include("cfitsio.jl")  # Low-level cfitsio functions
 include("hdutypes.jl")  # HDU type interface
+include("deprecations.jl")  # deprecated low-level cfitsio methods
 
 end # module

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,9 @@
+import Base: @deprecate
+
+# Deprecated in v0.6
+
+@deprecate fits_get_col_repeat(f::FITSFile, colnum::Integer) fits_get_coltype(f, colnum)[2, 3]
+
+@deprecate fits_read_col{T}(f::FITSFile, ::Type{T}, colnum::Integer, firstrow::Integer, firstelem::Integer, data::Array{T}) fits_read_col(f, colnum, firstrow, firstelem, data)
+
+@deprecate fits_write_col{T}(f::FITSFile, ::Type{T}, colnum::Integer, firstrow::Integer, firstelem::Integer, data::Array{T}) fits_write_col(f, colnum, firstrow, firstelem, data)


### PR DESCRIPTION
- move the definitions of `fits_get_coltype`, `fits_get_eqcoltype`, `fits_read_tdim` to earlier in the file so that `fits_get_coltype` can be used in `fits_read_col` instead of the deprecated function `fits_get_col_repeat`.
- move deprecated functions/methods to a separate file `deprecations.jl` and use the `@deprecated` macro to emit a deprecation warning.

@emmt should review this. Tests pass locally but there's no tests for the table functions yet, so it is not a very good indicator!