### PR TITLE
non-standard header values

### DIFF
--- a/src/cfitsio.jl
+++ b/src/cfitsio.jl
@@ -14,7 +14,8 @@
 #   `@compat Vector{T}(x)` once syntax support is in Compat.
 # - `convert(Cint, x)` can be changed to `Cint(x)` once v0.3 is not supported
 #   or `@compat Cint(x)` once syntax support is in Compat.
-#
+# - Once v0.3 is no longer supported, the type `Nothing` should be changed to
+#   `Void` (this is the type of `nothing`).
 #
 # The following table gives the correspondances between CFITSIO "types",
 # the BITPIX keyword and Julia types.
@@ -299,6 +300,15 @@ function fits_update_key(f::FITSFile, key::ASCIIString, value::FloatingPoint,
     ccall(("ffukyd", libcfitsio), Cint,
           (Ptr{Void}, Ptr{Uint8}, Cdouble, Cint, Ptr{Uint8}, Ptr{Cint}),
           f.ptr, key, value, -15, comment, status)
+    fits_assert_ok(status[1])
+end
+
+function fits_update_key(f::FITSFile, key::ASCIIString, value::Nothing,
+                         comment::Union(ASCIIString, Ptr{Void})=C_NULL)
+    status = Cint[0]
+    ccall(("ffukyu", libcfitsio), Cint,
+          (Ptr{Void}, Ptr{Uint8}, Ptr{Uint8}, Ptr{Cint}),
+          f.ptr, key, comment, status)
     fits_assert_ok(status[1])
 end
 

--- a/src/hdutypes.jl
+++ b/src/hdutypes.jl
@@ -157,11 +157,19 @@ function parse_header_val(val::ASCIIString)
         catch
         end
     end
-    val == "T" ? true :
-    val == "F" ? false :
-    val == "" ? nothing :
-    length(val) > 1 && val[1] == '\'' && val[end] == '\'' ? val[2:end-1] :
-    error("couldn't parse keyword value: \"$val\"")
+    if val == "T"
+        return true
+    elseif val == "F"
+        return false
+    elseif val == ""
+        return nothing  # The value area is empty.
+    elseif length(val) > 1 && val[1] == '\'' && val[end] == '\''
+        return val[2:end-1]  # The value is a string. Strip the quotes.
+                             # TODO: strip any trailing white space?
+    else
+        return val  # The value (probably) doesn't comply with the FITS
+                    # standard. Give up and return the unparsed string.
+    end
 end
 
 function readkey(hdu::HDU, key::Integer)

--- a/src/hdutypes.jl
+++ b/src/hdutypes.jl
@@ -165,7 +165,6 @@ function parse_header_val(val::ASCIIString)
         return nothing  # The value area is empty.
     elseif length(val) > 1 && val[1] == '\'' && val[end] == '\''
         return val[2:end-1]  # The value is a string. Strip the quotes.
-                             # TODO: strip any trailing white space?
     else
         return val  # The value (probably) doesn't comply with the FITS
                     # standard. Give up and return the unparsed string.
@@ -250,22 +249,36 @@ end
 
 # Display the header
 hdrval_to_str(val::Bool) = val ? "T" : "F"
-hdrval_to_str(val::Nothing) = ""
 hdrval_to_str(val::ASCIIString) = @sprintf "'%s'" val
 hdrval_to_str(val::Union(FloatingPoint, Integer)) = string(val)
-
 function show(io::IO, hdr::FITSHeader)
     for i=1:length(hdr)
-        if hdr.keys[i] == "COMMENT"
-            @printf "COMMENT %s\n" hdr.comments[i]
-        elseif hdr.keys[i] == "HISTORY"
-            @printf "HISTORY %s\n" hdr.comments[i]
-        else
-            @printf "%-8s= %20s" hdr.keys[i] hdrval_to_str(hdr.values[i]) 
-            if length(hdr.comments[i]) > 0
-                @printf " / %s" hdr.comments[i]
+        cl = length(hdr.comments[i])
+        if hdr.keys[i] == "COMMENT" || hdr.keys[i] == "HISTORY"
+            if cl > 71
+                @printf io "%s %s\n" hdr.keys[i] hdr.comments[i][1:71]
+            else
+                @printf io "%s %s\n" hdr.keys[i] hdr.comments[i]
             end
-            print("\n")
+        else
+            @printf io "%-8s" hdr.keys[i]
+            if hdr.values[i] === nothing
+                print(io, "                      ")
+                rc = 50  # remaining characters on line
+            else
+                val = hdrval_to_str(hdr.values[i])
+                @printf io "= %20s" val
+                rc = length(val) <= 20 ? 50 : 70 - length(val)
+            end
+
+            if cl > 0
+                if cl > rc - 3
+                    @printf io " / %s" hdr.comments[i][1:rc-3]
+                else
+                    @printf io " / %s" hdr.comments[i]
+                end
+            end
+            print(io, "\n")
         end
     end
 end


### PR DESCRIPTION
This is a simple fix for #24. To explain: cfitsio returns header values as strings. In the high-level interface `FITSHeader`, we parse these strings into their implied types, for convenience. First we try to parse as an int, then a float, then a bool, then nothing, then a string (if value is surrounded by `'`). What to do when we get to the end? Formerly we raised an error saying that the value couldn't be parsed. This PR changes the behavior to simply return the unparsed string.

The upside of the change is that a single malformed keyword will no longer prevent one from reading the entire header. The slight downside is that you can't tell if the original unparsed value was a correctly quoted string or a malformed value that we gave up parsing. The upside outweighs the downside, but it made me think about whether we should keep the unparsed header in memory so that we can write it back out *exactly* as the original.

~~While checking the behavior of this non-standard file I also ran into another bug that I'll add a fix for here before we merge.~~ *edit:* Done. Formerly, records that were not COMMENT or HISTORY with an empty value field caused writing the header out to fail, even though these are valid FITS. I added a method to `fits_update_key()` for `Nothing`/`Void` values.

*edit:* Added regression test for such non-standard keywords like the ones in #24. We can add future pathological cases along side these.

*edit:* Fixed a problem with `show(::IO, ::FITSHeader)` where lines could wrap past 80 characters (became apparent with a comment that was longer than 47 characters).