### PR TITLE
a few fixes

### DIFF
--- a/src/hdutypes.jl
+++ b/src/hdutypes.jl
@@ -24,7 +24,7 @@ end
 # FITS is analagous to FITSFile, but holds a reference to all of its
 # HDU objects. This is so that only a single HDU object is created for
 # each extension in the file. It also allows a FITS object to tell
-# previously created HDUs about events that happen to the file, such 
+# previously created HDUs about events that happen to the file, such
 # as deleting extensions. This could be done by, e.g., setting ext=-1 in
 # the HDU object.
 type FITS
@@ -191,10 +191,10 @@ function readheader(hdu::HDU)
 
     # Below, we use a direct call to ffgkyn so that we can keep reusing the
     # same buffers.
-    key = Array(Uint8, 9)
-    value = Array(Uint8, 71)
-    comment = Array(Uint8, 71)
-    status = Int32[0]
+    key = Array(Uint8, 81)
+    value = Array(Uint8, 81)
+    comment = Array(Uint8, 81)
+    status = Cint[0]
 
     nkeys, morekeys = fits_get_hdrspace(hdu.fitsfile)
 
@@ -203,8 +203,8 @@ function readheader(hdu::HDU)
     values = Array(Any, nkeys)
     comments = Array(ASCIIString, nkeys)
     for i=1:nkeys
-        ccall((:ffgkyn,libcfitsio), Int32,
-              (Ptr{Void},Int32,Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},Ptr{Int32}),
+        ccall((:ffgkyn,libcfitsio), Cint,
+              (Ptr{Void},Cint,Ptr{Uint8},Ptr{Uint8},Ptr{Uint8},Ptr{Cint}),
               hdu.fitsfile.ptr, i, key, value, comment, status)
         keys[i] = bytestring(pointer(key))
         values[i] = parse_header_val(bytestring(pointer(value)))
@@ -289,7 +289,7 @@ const RESERVED_KEYS = ["SIMPLE","EXTEND","XTENSION","BITPIX","PCOUNT","GCOUNT",
                        "ZTENSION","ZPCOUNT","ZGCOUNT","ZBITPIX","ZEXTEND",
                        "CHECKSUM","DATASUM"]
 
-# This is more complex than you would think because some reserved keys 
+# This is more complex than you would think because some reserved keys
 # are only reserved when other keys are present. Also, in general a key
 # may appear more than once in a header.
 function reserved_key_indicies(hdr::FITSHeader)


### PR DESCRIPTION
A few changes to:
* have methods like `readheader` and `readkey` also available at the low level interface;
* fix a bug in `readheader` (buffer overflow) when dealing with keywords longer than 8 characters (e.g. HIERARCH keywords), the 3 byte buffers are now large enough to store the complete FITS card (which is safe although probably too large but that's only 3x81 bytes....);
* optimize `parse_header_val` (having the try...catch statements used in last resort) and remove trailing spaces in string vales (according to FITS convetion that trailing spaces are insignificant).