### PR TITLE
Read/write variable-length table columns

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright (c) 2012 Mike Nolta <mike@nolta.net>
+Copyright (c) 2012 - 2015 FITSIO.jl authors
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 v0.7.0 (unreleased)
 ===================
 
+## New Features
+
+- Read and write variable length columns in binary tables.
+
 ## Deprecations
 
 - `Libcfitsio.fits_read_num_rowsll` deprecated.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,6 @@ Flexible Image Transport System (FITS) support for Julia
 [![Build Status](https://img.shields.io/travis/JuliaAstro/FITSIO.jl.svg?style=flat-square)](https://travis-ci.org/JuliaAstro/FITSIO.jl)
 [![Coverage Status](http://img.shields.io/coveralls/JuliaAstro/FITSIO.jl.svg?style=flat-square)](https://coveralls.io/r/JuliaAstro/FITSIO.jl?branch=master)
 
-Installation
-------------
+Documentation: https://julia-fitsio.readthedocs.org/
 
-```jlcon
-julia> Pkg.add("FITSIO")
-```
-
-Complete Documentation
-----------------------
-
-https://julia-fitsio.readthedocs.org/
+License: MIT

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -121,7 +121,7 @@ Image operations
 Table Operations
 ----------------
 
-.. function:: write(f::FITS, data::Dict; hdutype=TableHDU, extname=nothing, header=nothing, units=nothing)
+.. function:: write(f::FITS, data::Dict; hdutype=TableHDU, extname=nothing, header=nothing, units=nothing, varcols=nothing)
 
    Create a new table extension and write data to it. If the FITS file
    is currently empty then a dummy primary array will be created
@@ -131,7 +131,7 @@ Table Operations
    types are supported in binary tables: ``Uint8``, ``Int8``,
    ``Uint16``, ``Int16``, ``Uint32``, ``Int32``, ``Int64``,
    ``Float32``, ``Float64``, ``Complex64``, ``Complex128``,
-   ``ASCIIString``, ``Bool``
+   ``ASCIIString``, ``Bool``.
 
    Optional inputs:
    
@@ -140,14 +140,29 @@ Table Operations
    - ``extname``: Name of extension.
    - ``header``: FITSHeader instance to write to new extension.
    - ``units``: Dictionary mapping column name to units (as a string).
+   - ``varcols``: An array giving the column names or column indicies to
+     write as "variable-length columns".
 
-.. function:: write(f::FITS, colnames, coldata; hdutype=TableHDU, extname=nothing, header=nothing, units=nothing)
+   .. note:: Variable length columns
+
+      Variable length columns allow a column's row entries to contain
+      arrays of different lengths. They can potentially save diskspace
+      when the rows of a column vary greatly in length, as the column
+      data is all written to a contiguous heap area at the end of the
+      table. Only column data of type ``Vector{ASCIIString}`` or types
+      such as ``Vector{Vector{UInt8}}`` can be written as variable
+      length columns. In the second case, ensure that the column data
+      type is a *leaf type*. That is, the type cannot be
+      ``Vector{Vector{T}}``, which would be an array of arrays having
+      potentially non-uniform element types (which would not be
+      writable as a FITS table column).
+
+.. function:: write(f::FITS, colnames, coldata; hdutype=TableHDU, extname=nothing, header=nothing, units=nothing, varcols=nothing)
 
    Same as ``write(f::FITS, data::Dict; ...)`` but providing column
-   names and column data as a separate arrays. Column names must be
-   ``Array{ASCIIString}`` and column data must be an array of
-   arrays. Their lengths should match. This is useful for specifying
-   the order of the columns.
+   names and column data as a separate arrays. This is useful for
+   specifying the order of the columns. Column names must be
+   ``Array{ASCIIString}`` and column data must be an array of arrays.
 
 .. function:: read(hdu, colname)
 

--- a/src/cfitsio.jl
+++ b/src/cfitsio.jl
@@ -764,7 +764,7 @@ function fits_read_col(f::FITSFile,
           (Ptr{Void}, Cint, Int64, Int64, Int64,
            Ptr{Uint8}, Ptr{Ptr{Uint8}}, Ptr{Cint}, Ptr{Cint}),
           f.ptr, colnum, firstrow, firstelem, length(data),
-          "", buffers, anynull, status)
+          " ", buffers, anynull, status)
     fits_assert_ok(status[1])
 
     # Create strings out of the buffers, terminating at null characters.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,15 +78,18 @@ end
 i = length(indata) + 1
 indata["col$i"] = [randstring(10) for j=1:20]  # ASCIIString column
 i += 1
-indata["col$i"] = [true for i=1:20]  # Bool column
+indata["col$i"] = ones(Bool, 20)  # Bool column
 i += 1
 indata["col$i"] = reshape([1:40;], (2, 20))  # vector Int64 column
 i += 1
 indata["col$i"] = [randstring(5) for j=1:2, k=1:20]  # vector ASCIIString col
+indata["vcol1"] = [randstring(j) for j=1:20]  # variable length column
+indata["vcol2"] = [collect(1.:j) for j=1.:20.] # variable length
 
-write(f, indata)
+# test writing
+write(f, indata; varcols=["vcol1", "vcol2"])
 
-# test 
+# test reading
 for (colname, incol) in indata
     outcol = read(f[2], colname)  # table is in extension 2 (1 = primary hdr)
     @test outcol == incol


### PR DESCRIPTION
On reading, variable-length columns are automatically read into `Vector{Vector{T}}` or `Vector{ASCIIString}` (for string columns).

On writing a new table, the `varcols` keyword can be used to specify which columns should be written as variable length. This is necessary because `Vector{ASCIIString}` can go either way. Other types must be vectors of vectors in order to be written as variable-length.