### PR TITLE
Windows support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,16 @@
-language: c
-compiler:
-  - clang
+language: julia
+os:
+    - linux
+julia:
+    - release
+    - nightly
 notifications:
-  email: false
-env:
-  matrix: 
-    - JULIAVERSION="juliareleases" 
-    - JULIAVERSION="julianightlies" 
+    email: false
 before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-  - sudo apt-get install libcfitsio3 -y
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    - sudo apt-get update -qq -y
+    - sudo apt-get install libcfitsio3 -y
 script:
-  - julia -e 'Pkg.init(); Pkg.clone(pwd())'
-  - julia -e 'Pkg.build("FITSIO")'
-  - julia -e 'Pkg.test("FITSIO"; coverage=true)'
+    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    - julia -e 'Pkg.clone(pwd()); Pkg.build("FITSIO"); Pkg.test("FITSIO"; coverage=true)';
 after_success:
-  - julia -e 'cd(Pkg.dir("FITSIO")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+    - julia -e 'cd(Pkg.dir("FITSIO")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,17 @@
 v0.8.0 (unreleased)
 ===================
 
-## New Features
+## New features
 
+- Windows support (32-bit & 64-bit), thanks to help from Tony Kelman
 - New method `read_header(hdu, ASCIIString)` returns entire header as
   a single string.
+- bump cfitsio version from 3.360 to 3.370
+
+## Bug fixes
+
+- fix `show()` for an empty FITS file.
+- fix several issues with `Clong` on 64-bit Windows.
 
 v0.7.0 (2015-05-31)
 ===================

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ FITSIO.jl
 Flexible Image Transport System (FITS) support for Julia
 
 [![Build Status](https://img.shields.io/travis/JuliaAstro/FITSIO.jl.svg?style=flat-square)](https://travis-ci.org/JuliaAstro/FITSIO.jl)
+[![Build status](https://ci.appveyor.com/api/projects/status/deo8f6yrcf94rc2k/branch/master?svg=true)](https://ci.appveyor.com/project/kbarbary/fitsio-jl/branch/master)
 [![Coverage Status](http://img.shields.io/coveralls/JuliaAstro/FITSIO.jl.svg?style=flat-square)](https://coveralls.io/r/JuliaAstro/FITSIO.jl?branch=master)
 
 Documentation: https://julia-fitsio.readthedocs.org/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+environment:
+  matrix:
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.3/julia-0.3-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.3/julia-0.3-latest-win64.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+# Download most recent Julia Windows binary
+  - ps: (new-object net.webclient).DownloadFile(
+        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
+        "C:\projects\julia-binary.exe")
+# Run installer silently, output to C:\projects\julia
+  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+
+build_script:
+# Need to convert from shallow to complete for Pkg.clone to work
+  - IF EXIST .git\shallow (git fetch --unshallow)
+  - C:\projects\julia\bin\julia -e "versioninfo();
+      Pkg.add(\"BinDeps\"); Pkg.checkout(\"BinDeps\");
+      Pkg.clone(pwd(), \"FITSIO\"); Pkg.build(\"FITSIO\")"
+
+test_script:
+  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"FITSIO\")"

--- a/src/header.jl
+++ b/src/header.jl
@@ -76,7 +76,10 @@ hdrval_repr(v::Union(FloatingPoint, Integer)) = string(v)
 
 # returns one of: ASCIIString, Bool, Int, Float64, nothing
 # (never error)
-parse_header_val(s::ASCIIString) = get(try_parse_hdrval(s), s)
+function parse_header_val(s::ASCIIString)
+    nval = try_parse_hdrval(s)
+    return isnull(nval) ? s : get(nval)
+end
 
 # Try to read the raw keys in order given; returns Nullable.
 # (null if no key exists or if parsing an existing key is unsuccessful.)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,6 +131,15 @@ isfile(fname) && rm(fname)
 
 fname = tempname() * ".fits"
 f = FITS(fname, "w")
+
+# test that show() works on an empty file and that the beginning and end
+# arre what we expect.
+io = IOBuffer()
+show(io, f)
+s = takebuf_string(io)
+@test s[1:6] == "File: "
+@test s[end-7:end] == "No HDUs."
+
 inhdr = FITSHeader(["FLTKEY", "INTKEY", "BOOLKEY", "STRKEY", "COMMENT",
                     "HISTORY"],
                    [1.0, 1, true, "string value", nothing, nothing],


### PR DESCRIPTION
@tkelman's JuliaCon talk inspired me to start supporting Windows. In this case, it should be pretty easy because there are pre-built windows binaries for cfitsio on the cfitsio homepage.

I don't expect this PR to work immediately, as I've probably got the BinDeps build script wrong. This is mainly to try AppVeyor out.

Quick question for Tony: The [cfitsio homepage](http://heasarc.gsfc.nasa.gov/docs/software/fitsio/) provides both MSVC and Borland binaries. Do we have to worry about using the later? (I have no experience with Windows!)