### PR TITLE
fix scalar indexing in Julia 0.5

### DIFF
--- a/src/image.jl
+++ b/src/image.jl
@@ -86,8 +86,13 @@ _index_shape_dim(sz, dim, ::Colon) = (sz[dim],)
 _index_shape_dim(sz, dim, r::Range) = (length(r),)
 @inline _index_shape_dim(sz, dim, ::Colon, I...) =
     tuple(sz[dim], _index_shape_dim(sz, dim+1, I...)...)
-@inline _index_shape_dim(sz, dim, ::Integer, I...) =
-    tuple(1, _index_shape_dim(sz, dim+1, I...)...)
+if VERSION >= v"0.5.0-dev"  # In Julia v0.5+ drop scalar-indexed dimensions.
+    @inline _index_shape_dim(sz, dim, ::Integer, I...) =
+        _index_shape_dim(sz, dim+1, I...)
+else
+    @inline _index_shape_dim(sz, dim, ::Integer, I...) =
+        tuple(1, _index_shape_dim(sz, dim+1, I...)...)
+end
 @inline _index_shape_dim(sz, dim, r::Range, I...) =
     tuple(length(r), _index_shape_dim(sz, dim+1, I...)...)
 


### PR DESCRIPTION
This fixes tests on Julia v0.5, by making `read(hdu, 1, 1:10)` return an `Array{T, 1}` instead of `Array{T, 2}`, in line with how `data[1, 1:10]` now works.

It would probably be good to have a more precise version for this change if anyone knows it. Right now the test is just  `VERSION >= v"0.5.0-dev"`.