### PR TITLE
fix use of cp on windows build

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -53,7 +53,7 @@ provides(BuildProcess,
 	     @build_steps begin
 		 ChangeDirectory(srcdir)
 	         FileRule(joinpath(libdir, libfilename), @build_steps begin
-		          `cp $(libfilename) $(joinpath(libdir, libfilename))`
+		          `powershell -Command "cp $(libfilename) $(joinpath(libdir, libfilename))"`
 			  end)
              end
 	  end), libcfitsio, os = :Windows)


### PR DESCRIPTION
Trying to address #52.