### PR TITLE
Updates for Julia 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - linux
     - osx
 julia:
-    - 0.3
     - 0.4
     - 0.5
     - nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.4
 BinDeps 0.3.12
 Compat 0.8.6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.3/julia-0.3-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.3/julia-0.3-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/fits.jl
+++ b/src/fits.jl
@@ -55,9 +55,9 @@ function show(io::IO, f::FITS)
     else
         print(io, "HDUs: ")
 
-        names = Array(Compat.ASCIIString, nhdu)
-        vers = Array(Compat.ASCIIString, nhdu)
-        types = Array(Compat.ASCIIString, nhdu)
+        names = Vector{Compat.ASCIIString}(nhdu)
+        vers = Vector{Compat.ASCIIString}(nhdu)
+        types = Vector{Compat.ASCIIString}(nhdu)
         for i = 1:nhdu
             t = fits_movabs_hdu(f.fitsfile, i)
             types[i] = (t == :image_hdu ? "Image" :

--- a/src/header.jl
+++ b/src/header.jl
@@ -85,7 +85,7 @@ end
 # (null if no key exists or if parsing an existing key is unsuccessful.)
 function fits_try_read_keys{T}(f::FITSFile, ::Type{T}, keys)
     status = Cint[0]
-    value = Array(UInt8, 71)
+    value = Vector{UInt8}(71)
     for key in keys
         ccall((:ffgkey, libcfitsio), Cint,
               (Ptr{Void},Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Ptr{Cint}),
@@ -223,17 +223,17 @@ function read_header(hdu::HDU)
 
     # Below, we use a direct call to ffgkyn so that we can keep reusing the
     # same buffers.
-    key = Array(UInt8, 81)
-    value = Array(UInt8, 81)
-    comment = Array(UInt8, 81)
+    key = Vector{UInt8}(81)
+    value = Vector{UInt8}(81)
+    comment = Vector{UInt8}(81)
     status = Cint[0]
 
     nkeys, morekeys = fits_get_hdrspace(hdu.fitsfile)
 
     # Initialize output arrays
-    keys = Array(Compat.ASCIIString, nkeys)
-    values = Array(Any, nkeys)
-    comments = Array(Compat.ASCIIString, nkeys)
+    keys = Vector{Compat.ASCIIString}(nkeys)
+    values = Vector{Any}(nkeys)
+    comments = Vector{Compat.ASCIIString}(nkeys)
     for i=1:nkeys
         ccall((:ffgkyn,libcfitsio), Cint,
               (Ptr{Void},Cint,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Ptr{Cint}),

--- a/src/image.jl
+++ b/src/image.jl
@@ -58,7 +58,7 @@ function read(hdu::ImageHDU)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
     sz = fits_get_img_size(hdu.fitsfile)
     bitpix = fits_get_img_equivtype(hdu.fitsfile)
-    data = Array(TYPE_FROM_BITPIX[bitpix], sz...)
+    data = Array{TYPE_FROM_BITPIX[bitpix]}(sz...)
     fits_read_pix(hdu.fitsfile, data)
     data
 end
@@ -119,7 +119,7 @@ function read_internal(hdu::ImageHDU, I::@compat(Union{Range{Int}, Integer, Colo
 
     # construct output array
     bitpix = fits_get_img_equivtype(hdu.fitsfile)
-    data = Array(TYPE_FROM_BITPIX[bitpix], _index_shape(sz, I...))
+    data = Array{TYPE_FROM_BITPIX[bitpix]}(_index_shape(sz, I...))
 
     fits_read_subset(hdu.fitsfile, firsts, lasts, steps, data)
     data

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,7 +136,7 @@ f = FITS(fname, "w")
 # arre what we expect.
 io = IOBuffer()
 show(io, f)
-s = takebuf_string(io)
+s = String(take!(io))
 @test s[1:6] == "File: "
 @test s[end-7:end] == "No HDUs."
 
@@ -190,7 +190,7 @@ s_reread = read_header(f[1], Compat.ASCIIString)
 # Test that show() works and that the beginning of output is what we expect.
 io = IOBuffer()
 show(io, f)
-s = takebuf_string(io)
+s = String(take!(io))
 @test s[1:6] == "File: "
 
 # Clean up from last test.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using FITSIO
 using Base.Test
 using Compat
+import Compat.String
 
 # -----------------------------------------------------------------------------
 # Images
@@ -136,7 +137,7 @@ f = FITS(fname, "w")
 # arre what we expect.
 io = IOBuffer()
 show(io, f)
-s = String(take!(io))
+s = @compat(String(take!(io)))
 @test s[1:6] == "File: "
 @test s[end-7:end] == "No HDUs."
 
@@ -190,7 +191,7 @@ s_reread = read_header(f[1], Compat.ASCIIString)
 # Test that show() works and that the beginning of output is what we expect.
 io = IOBuffer()
 show(io, f)
-s = String(take!(io))
+s = @compat(String(take!(io)))
 @test s[1:6] == "File: "
 
 # Clean up from last test.


### PR DESCRIPTION
Mainly the deprecation of the old `Array` constructor. I'm also using `Ref` in `ccall`s whenever possible. Finally, I'm dropping Julia 0.3 support since some of these changes won't work there and I don't think it is relevant to support anymore.