### PR TITLE
Support memory backed files

### DIFF
--- a/src/fits.jl
+++ b/src/fits.jl
@@ -49,15 +49,15 @@ function show(io::IO, f::FITS)
     """)
 
     nhdu = length(f)
-    
+
     if nhdu == 0
         print(io, "No HDUs.")
     else
         print(io, "HDUs: ")
 
-        names = Array(Compat.ASCIIString, nhdu)
-        vers = Array(Compat.ASCIIString, nhdu)
-        types = Array(Compat.ASCIIString, nhdu)
+        names = Vector{Compat.ASCIIString}(nhdu)
+        vers = Vector{Compat.ASCIIString}(nhdu)
+        types = Vector{Compat.ASCIIString}(nhdu)
         for i = 1:nhdu
             t = fits_movabs_hdu(f.fitsfile, i)
             types[i] = (t == :image_hdu ? "Image" :
@@ -69,7 +69,7 @@ function show(io::IO, f::FITS)
             nver = fits_try_read_extver(f.fitsfile)
             vers[i] = isnull(nver) ? "" : string(get(nver))
         end
-        
+
         nums = [string(i) for i=1:nhdu]
 
         # only display version info if present

--- a/src/header.jl
+++ b/src/header.jl
@@ -85,7 +85,7 @@ end
 # (null if no key exists or if parsing an existing key is unsuccessful.)
 function fits_try_read_keys{T}(f::FITSFile, ::Type{T}, keys)
     status = Cint[0]
-    value = Array(UInt8, 71)
+    value = Vector{UInt8}(71)
     for key in keys
         ccall((:ffgkey, libcfitsio), Cint,
               (Ptr{Void},Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Ptr{Cint}),

--- a/src/libcfitsio.jl
+++ b/src/libcfitsio.jl
@@ -67,6 +67,7 @@ module Libcfitsio
 using Compat
 
 export FITSFile,
+       FITSMemoryHandle,
        fits_assert_open,
        fits_clobber_file,
        fits_close_file,
@@ -106,6 +107,7 @@ export FITSFile,
        fits_open_file,
        fits_open_image,
        fits_open_table,
+       fits_open_memfile,
        fits_read_col,
        fits_read_descript,
        fits_read_keyn,
@@ -182,6 +184,14 @@ type FITSFile
     end
 end
 
+# FITS wants to be able to update the ptr, so keep them
+# in a mutable struct
+type FITSMemoryHandle
+    ptr::Ptr{Void}
+    size::Csize_t
+end
+FITSMemoryHandle() = FITSMemoryHandle(C_NULL, 0)
+
 # -----------------------------------------------------------------------------
 # error messaging
 
@@ -192,7 +202,7 @@ function fits_assert_open(f::FITSFile)
 end
 
 function fits_get_errstatus(status::Cint)
-    msg = Array(UInt8, 31)
+    msg = Vector{UInt8}(31)
     ccall((:ffgerr,libcfitsio), Void, (Cint,Ptr{UInt8}), status, msg)
     unsafe_string(pointer(msg))
 end
@@ -225,15 +235,32 @@ for (a,b) in ((:fits_open_data, "ffdopn"),
               (:fits_open_table,"fftopn"))
     @eval begin
         function ($a)(filename::AbstractString, mode::Integer=0)
-            ptr = Array(Ptr{Void}, 1)
-            status = Cint[0]
+            ptr = Ref{Ptr{Void}}()
+            status = Ref{Cint}(0)
             ccall(($b,libcfitsio), Cint,
                   (Ptr{Ptr{Void}},Ptr{UInt8},Cint,Ptr{Cint}),
                   ptr, filename, mode, status)
-            fits_assert_ok(status[1])
-            FITSFile(ptr[1])
+            fits_assert_ok(status[])
+            FITSFile(ptr[])
         end
     end
+end
+
+# filename is ignored by the C library
+function fits_open_memfile(data::Vector{UInt8}, mode::Integer=0, filename="")
+    # Only reading is supported right now
+    @assert mode == 0
+    ptr = Ref{Ptr{Void}}(C_NULL)
+    status = Ref{Cint}(0)
+    handle = FITSMemoryHandle(pointer(data),length(data))
+    dataptr = Ptr{Ptr{Void}}(pointer_from_objref(handle))
+    sizeptr = Ptr{Csize_t}(dataptr+sizeof(Ptr{Void}))
+    ccall(("ffomem",libcfitsio), Cint,
+      (Ptr{Ptr{Void}},Ptr{UInt8},Cint,Ptr{Ptr{UInt8}},
+       Ptr{Csize_t}, Csize_t, Ptr{Void}, Ptr{Cint}),
+       ptr, filename, mode, dataptr, sizeptr, 2880, C_NULL, status)
+    fits_assert_ok(status[])
+    FITSFile(ptr[]), handle
 end
 
 for (a,b) in ((:fits_close_file, "ffclos"),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -251,6 +251,13 @@ hdr = read_header(f[1])
 data = read(f[1])
 close(f)
 
+# Test that we can read is at a memory backed file
+f = FITS(read(fname))
+hdr = read_header(f[1])
+data = read(f[1])
+close(f)
+
+
 # test that we can write it back out.
 fname2 = tempname() * ".fits"
 f2 = FITS(fname2, "w")


### PR DESCRIPTION
Support read-only memory backed files via `ffomem`. Also clean up a couple of deprecations
while I'm here.