### PR TITLE
Clear deprecation warnings in Julia 0.6

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -9,7 +9,7 @@ baseurl = "ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/"
 if is_unix()
     archivename = "cfitsio$(version).tar.gz"
 elseif is_windows()
-    archivename = "cfitsio_MSVC_$(WORD_SIZE)bit_DLL_$(version).zip"
+    archivename = "cfitsio_MSVC_$(Sys.WORD_SIZE)bit_DLL_$(version).zip"
 end
 
 libcfitsio = library_dependency("libcfitsio", aliases=["cfitsio"])

--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -123,7 +123,7 @@ type FITSHeader
         for i in 1:length(keys)
           map[keys[i]] = i
         end
-        new(keys, convert(Vector{Any}, values), comments, map)
+        new(keys, Vector{Any}(values), comments, map)
     end
 end
 
@@ -135,7 +135,7 @@ include("table.jl")  # TableHDU & ASCIITableHDU methods
 function libcfitsio_version()
     # fits_get_version returns a float. e.g., 3.341f0. We parse that
     # into a proper version number. E.g., 3.341 -> v"3.34.1"
-    v = convert(Int, round(1000 * fits_get_version()))
+    v = Int(round(1000 * fits_get_version()))
     x = div(v, 1000)
     y = div(rem(v, 1000), 10)
     z = rem(v, 10)

--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -47,7 +47,7 @@ import .Libcfitsio: libcfitsio,
                     TYPE_FROM_BITPIX
 
 # HDU Types
-abstract HDU
+@compat abstract type HDU end
 
 type ImageHDU <: HDU
     fitsfile::FITSFile

--- a/src/fits.jl
+++ b/src/fits.jl
@@ -1,8 +1,8 @@
 # FITS methods
 
-const VERBOSE_MODE = @compat Dict("r"=>"read-only",
-                                  "w"=>"read-write",
-                                  "r+"=>"append")
+const VERBOSE_MODE = Dict("r"=>"read-only",
+                          "w"=>"read-write",
+                          "r+"=>"append")
 
 # helper function for show()
 function show_ascii_table(io, names, cols, spaces=2, indent=0)
@@ -31,7 +31,7 @@ end
 
 function length(f::FITS)
     fits_assert_open(f.fitsfile)
-    @compat Int(fits_get_num_hdus(f.fitsfile))
+    Int(fits_get_num_hdus(f.fitsfile))
 end
 
 endof(f::FITS) = length(f)

--- a/src/header.jl
+++ b/src/header.jl
@@ -72,7 +72,7 @@ end
 # functions for displaying header values in show(io, header)
 hdrval_repr(v::Bool) = v ? "T" : "F"
 hdrval_repr(v::Compat.ASCIIString) = @sprintf "'%s'" v
-hdrval_repr(v::@compat(Union{AbstractFloat, Integer})) = string(v)
+hdrval_repr(v::Union{AbstractFloat, Integer}) = string(v)
 
 # returns one of: Compat.ASCIIString, Bool, Int, Float64, nothing
 # (never error)

--- a/src/image.jl
+++ b/src/image.jl
@@ -70,12 +70,12 @@ _checkbounds(sz, r::Range{Int}) =
     (isempty(r) || (minimum(r) >= 1 && maximum(r) <= sz))
 
 # helper functions for constructing cfitsio indexing vectors in read(hdu, ...)
-_first(i::@compat(Union{Integer, Range})) = first(i)
+_first(i::Union{Integer, Range}) = first(i)
 _first(::Colon) = 1
-_last(sz, i::@compat(Union{Integer, Range})) = last(i)
+_last(sz, i::Union{Integer, Range}) = last(i)
 _last(sz, ::Colon) = sz
 _step(r::Range) = step(r)
-_step(::@compat(Union{Integer, Colon})) = 1
+_step(::Union{Integer, Colon}) = 1
 
 # Shape of array to create for read(hdu, ...), dropping trailing
 # scalars. This is simpler than in Base because we are guaranteed that
@@ -97,7 +97,7 @@ end
     tuple(length(r), _index_shape_dim(sz, dim+1, I...)...)
 
 # Read a subset of an ImageHDU
-function read_internal(hdu::ImageHDU, I::@compat(Union{Range{Int}, Integer, Colon})...)
+function read_internal(hdu::ImageHDU, I::Union{Range{Int}, Integer, Colon}...)
     fits_assert_open(hdu.fitsfile)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
     sz = fits_get_img_size(hdu.fitsfile)
@@ -126,7 +126,7 @@ function read_internal(hdu::ImageHDU, I::@compat(Union{Range{Int}, Integer, Colo
 end
 
 # general method and version that returns a single value rather than 0-d array
-read(hdu::ImageHDU, I::@compat(Union{Range{Int}, Int, Colon})...) =
+read(hdu::ImageHDU, I::Union{Range{Int}, Int, Colon}...) =
     read_internal(hdu, I...)
 read(hdu::ImageHDU, I::Int...) = read_internal(hdu, I...)[1]
 
@@ -134,9 +134,9 @@ read(hdu::ImageHDU, I::Int...) = read_internal(hdu, I...)[1]
 # The following Julia data types are supported for writing images by cfitsio:
 # Uint8, Int8, Uint16, Int16, Uint32, Int32, Int64, Float32, Float64
 function write{T}(f::FITS, data::Array{T};
-                  header::@compat(Union{Void, FITSHeader})=nothing,
-                  name::@compat(Union{Void, Compat.ASCIIString})=nothing,
-                  ver::@compat(Union{Void, Integer})=nothing)
+                  header::Union{Void, FITSHeader}=nothing,
+                  name::Union{Void, Compat.ASCIIString}=nothing,
+                  ver::Union{Void, Integer}=nothing)
     fits_assert_open(f.fitsfile)
     s = size(data)
     fits_create_img(f.fitsfile, T, [s...])

--- a/src/libcfitsio.jl
+++ b/src/libcfitsio.jl
@@ -353,7 +353,7 @@ function fits_read_keyn(f::FITSFile, keynum::Integer)
 end
 
 function fits_write_key(f::FITSFile, keyname::Compat.ASCIIString,
-                        value::@compat(Union{AbstractFloat,Compat.ASCIIString}),
+                        value::Union{AbstractFloat,Compat.ASCIIString},
                         comment::Compat.ASCIIString)
     cvalue = isa(value,Compat.ASCIIString) ?  value :
              isa(value,Bool) ? Cint[value] : [value]
@@ -385,7 +385,7 @@ for (a,T,S) in (("ffukys", :(Compat.ASCIIString), :(Ptr{UInt8})),
                 ("ffukyj", :Integer,     :Int64))
     @eval begin
         function fits_update_key(f::FITSFile, key::Compat.ASCIIString, value::$T,
-                                 comment::@compat(Union{Compat.ASCIIString, Ptr{Void}})=C_NULL)
+                                 comment::Union{Compat.ASCIIString, Ptr{Void}}=C_NULL)
             status = Ref{Cint}(0)
             ccall(($a, libcfitsio), Cint,
                   (Ptr{Void}, Ptr{UInt8}, $S, Ptr{UInt8}, Ref{Cint}),
@@ -396,7 +396,7 @@ for (a,T,S) in (("ffukys", :(Compat.ASCIIString), :(Ptr{UInt8})),
 end
 
 function fits_update_key(f::FITSFile, key::Compat.ASCIIString, value::AbstractFloat,
-                         comment::@compat(Union{Compat.ASCIIString, Ptr{Void}})=C_NULL)
+                         comment::Union{Compat.ASCIIString, Ptr{Void}}=C_NULL)
     status = Ref{Cint}(0)
     ccall(("ffukyd", libcfitsio), Cint,
           (Ptr{Void}, Ptr{UInt8}, Cdouble, Cint, Ptr{UInt8}, Ref{Cint}),
@@ -404,8 +404,8 @@ function fits_update_key(f::FITSFile, key::Compat.ASCIIString, value::AbstractFl
     fits_assert_ok(status[])
 end
 
-function fits_update_key(f::FITSFile, key::Compat.ASCIIString, value::@compat(Void),
-                         comment::@compat(Union{Compat.ASCIIString, Ptr{Void}})=C_NULL)
+function fits_update_key(f::FITSFile, key::Compat.ASCIIString, value::Void,
+                         comment::Union{Compat.ASCIIString, Ptr{Void}}=C_NULL)
     status = Ref{Cint}(0)
     ccall(("ffukyu", libcfitsio), Cint,
           (Ptr{Void}, Ptr{UInt8}, Ptr{UInt8}, Ref{Cint}),
@@ -615,7 +615,7 @@ end
 # ASCII/binary table HDU functions
 
 # The three fields are: ttype, tform, tunit (CFITSIO's terminology)
-const ColumnDef = @compat Tuple{Compat.ASCIIString, Compat.ASCIIString, Compat.ASCIIString}
+const ColumnDef = Tuple{Compat.ASCIIString, Compat.ASCIIString, Compat.ASCIIString}
 
 for (a,b) in ((:fits_create_binary_tbl, 2),
               (:fits_create_ascii_tbl,  1))
@@ -703,7 +703,7 @@ end
               (Ptr{Void}, Cint, Ref{Cint}, Ref{$T}, Ref{$T}, Ref{Cint}),
               ff.ptr, colnum, typecode, repcnt, width, status)
         fits_assert_ok(status[])
-        return @compat Int(typecode[]), Int(repcnt[]), Int(width[])
+        return Int(typecode[]), Int(repcnt[]), Int(width[])
     end
 
     function fits_get_eqcoltype(ff::FITSFile, colnum::Integer)
@@ -715,7 +715,7 @@ end
               (Ptr{Void}, Cint, Ref{Cint}, Ref{$T}, Ref{$T}, Ref{Cint}),
               ff.ptr, colnum, typecode, repcnt, width, status)
         fits_assert_ok(status[])
-        return @compat Int(typecode[]), Int(repcnt[]), Int(width[])
+        return Int(typecode[]), Int(repcnt[]), Int(width[])
     end
 
     function fits_get_img_size(f::FITSFile)
@@ -736,7 +736,7 @@ end
               (Ptr{Void}, Ref{$T}, Ref{Cint}),
               f.ptr, result, status)
         fits_assert_ok(status[])
-        return @compat Int(result[])
+        return Int(result[])
     end
 
     # `fits_read_tdim` returns the dimensions of a table column in a
@@ -772,7 +772,7 @@ end
               (Ptr{Void}, Cint, Int64, Ref{$T}, Ref{$T}, Ref{Cint}),
               f.ptr, colnum, rownum, repeat, offset, status)
         fits_assert_ok(status[])
-        return @compat Int(repeat[]), Int(offset[])
+        return Int(repeat[]), Int(offset[])
     end
 end
 

--- a/src/libcfitsio.jl
+++ b/src/libcfitsio.jl
@@ -615,7 +615,7 @@ end
 # ASCII/binary table HDU functions
 
 # The three fields are: ttype, tform, tunit (CFITSIO's terminology)
-typealias ColumnDef @compat Tuple{Compat.ASCIIString, Compat.ASCIIString, Compat.ASCIIString}
+const ColumnDef = @compat Tuple{Compat.ASCIIString, Compat.ASCIIString, Compat.ASCIIString}
 
 for (a,b) in ((:fits_create_binary_tbl, 2),
               (:fits_create_ascii_tbl,  1))

--- a/src/table.jl
+++ b/src/table.jl
@@ -30,9 +30,9 @@ for (T, tform, code) in ((UInt8,       'B',  11),
     @eval fits_tform_char(::Type{$T}) = $tform
     CFITSIO_COLTYPE[code] = T
 end
-typealias FITSTableScalar @compat(Union{UInt8, Int8, Bool, UInt16, Int16, UInt32,
-                                Int32, Int64, Float32, Float64, Complex64,
-                                Complex128})
+const FITSTableScalar = @compat(Union{UInt8, Int8, Bool, UInt16, Int16, UInt32,
+                                      Int32, Int64, Float32, Float64, Complex64,
+                                      Complex128})
 
 # Helper function for reading information about a (binary) table column
 # Returns: (eltype, rowsize, isvariable)
@@ -220,7 +220,7 @@ function show(io::IO, hdu::ASCIITableHDU)
     for i in 1:ncols
         eqtypecode, repeat, width = fits_get_eqcoltype(hdu.fitsfile, i)
         T = CFITSIO_COLTYPE[eqtypecode]
-        coltypes[i] = repr(T)        
+        coltypes[i] = repr(T)
     end
 
     print(io, """

--- a/src/table.jl
+++ b/src/table.jl
@@ -30,9 +30,9 @@ for (T, tform, code) in ((UInt8,       'B',  11),
     @eval fits_tform_char(::Type{$T}) = $tform
     CFITSIO_COLTYPE[code] = T
 end
-const FITSTableScalar = @compat(Union{UInt8, Int8, Bool, UInt16, Int16, UInt32,
-                                      Int32, Int64, Float32, Float64, Complex64,
-                                      Complex128})
+const FITSTableScalar = Union{UInt8, Int8, Bool, UInt16, Int16, UInt32,
+                              Int32, Int64, Float32, Float64, Complex64,
+                              Complex128}
 
 # Helper function for reading information about a (binary) table column
 # Returns: (eltype, rowsize, isvariable)
@@ -270,7 +270,7 @@ function write_internal(f::FITS, colnames::Vector{Compat.ASCIIString},
     fits_assert_open(f.fitsfile)
 
     # move to last HDU; table will be added after the CHDU
-    nhdus = @compat(Int(fits_get_num_hdus(f.fitsfile)))
+    nhdus = Int(fits_get_num_hdus(f.fitsfile))
     (nhdus > 1) && fits_movabs_hdu(f.fitsfile, nhdus)
 
     ncols = length(colnames)
@@ -278,7 +278,7 @@ function write_internal(f::FITS, colnames::Vector{Compat.ASCIIString},
 
     # determine which columns are requested to be variable-length
     isvarcol = zeros(Bool, ncols)
-    if !isa(varcols, @compat(Void))
+    if !isa(varcols, Void)
         for i=1:ncols
             isvarcol[i] = (i in varcols) || (colnames[i] in varcols)
         end
@@ -296,7 +296,7 @@ function write_internal(f::FITS, colnames::Vector{Compat.ASCIIString},
     tform = [pointer(s) for s in tform_str]
 
     # get units
-    if isa(units, @compat(Void))
+    if isa(units, Void)
         tunit = C_NULL
     else
         tunit = Ptr{UInt8}[(haskey(units, n)? pointer(units[n]): C_NULL)
@@ -304,7 +304,7 @@ function write_internal(f::FITS, colnames::Vector{Compat.ASCIIString},
     end
 
     # extension name
-    name_ptr = (isa(name, @compat(Void)) ? convert(Ptr{UInt8}, C_NULL) :
+    name_ptr = (isa(name, Void) ? convert(Ptr{UInt8}, C_NULL) :
                    pointer(name))
 
     status = Ref{Cint}(0)

--- a/src/table.jl
+++ b/src/table.jl
@@ -131,8 +131,8 @@ fits_tform(::Type{ASCIITableHDU}, A::Vector) = error("unsupported type: $(eltype
 fits_tform(::Type{ASCIITableHDU}, A::Array) = error("only 1-d arrays supported: dimensions are $(size(A))")
 
 # for passing to fits_create_tbl.
-table_type_code(::Type{ASCIITableHDU}) = convert(Cint, 1)
-table_type_code(::Type{TableHDU}) = convert(Cint, 2)
+table_type_code(::Type{ASCIITableHDU}) = Cint(1)
+table_type_code(::Type{TableHDU}) = Cint(2)
 
 function show(io::IO, hdu::TableHDU)
     fits_assert_open(hdu.fitsfile)
@@ -304,7 +304,7 @@ function write_internal(f::FITS, colnames::Vector{Compat.ASCIIString},
     end
 
     # extension name
-    name_ptr = (isa(name, Void) ? convert(Ptr{UInt8}, C_NULL) :
+    name_ptr = (isa(name, Void) ? Ptr{UInt8}(C_NULL) :
                    pointer(name))
 
     status = Ref{Cint}(0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -278,5 +278,3 @@ end
 
 # test that this function works and returns the right type.
 @test typeof(FITSIO.libcfitsio_version()) === VersionNumber
-
-println("All tests passed.")


### PR DESCRIPTION
I don't know what the `@compat` macro is used for in the definitions of `ColumnDef` and `FITSTableScalar`, can be removed?