### PR TITLE
Test libcfitsio_version

### DIFF
--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -147,10 +147,10 @@ include("header.jl")  # FITSHeader methods
 include("image.jl")  # ImageHDU methods
 include("table.jl")  # TableHDU & ASCIITableHDU methods
 
-function libcfitsio_version()
+function libcfitsio_version(version=fits_get_version())
     # fits_get_version returns a float. e.g., 3.341f0. We parse that
     # into a proper version number. E.g., 3.341 -> v"3.34.1"
-    v = Int(round(1000 * fits_get_version()))
+    v = Int(round(1000 * version))
     x = div(v, 1000)
     y = div(rem(v, 1000), 10)
     z = rem(v, 10)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -278,3 +278,6 @@ end
 
 # test that this function works and returns the right type.
 @test typeof(FITSIO.libcfitsio_version()) === VersionNumber
+# test it parses a number as intended.
+@test FITSIO.libcfitsio_version(3.341)  === VersionNumber(3, 34, 1)
+@test FITSIO.libcfitsio_version(3.41f0) === VersionNumber(3, 41, 0)


### PR DESCRIPTION
Add an optional argument to `libcfitsio_version` which defaults to `fits_get_version()`, so that it’s possible to test how the function parses a number as a VersionNumber.

This should prevent silly PR like #64 in the future :-D