### PR TITLE
additional functionality needed for LibHealpix.jl

### DIFF
--- a/src/libcfitsio.jl
+++ b/src/libcfitsio.jl
@@ -383,7 +383,7 @@ function fits_read_keyn(f::FITSFile, keynum::Integer)
 end
 
 function fits_write_key(f::FITSFile, keyname::Compat.ASCIIString,
-                        value::Union{Number,Compat.ASCIIString},
+                        value::Union{Real,Compat.ASCIIString},
                         comment::Compat.ASCIIString)
     cvalue = isa(value,Compat.ASCIIString) ?  value :
              isa(value,Bool) ? Cint[value] : [value]

--- a/src/libcfitsio.jl
+++ b/src/libcfitsio.jl
@@ -337,7 +337,7 @@ function fits_read_key_lng(f::FITSFile, keyname::Compat.ASCIIString)
 end
 
 function fits_read_keys_lng(f::FITSFile, keyname::Compat.ASCIIString,
-                            nstart::Int, nmax::Int)
+                            nstart::Integer, nmax::Integer)
     value = Vector{Clong}(nmax - nstart + 1)
     nfound = Ref{Cint}(0)
     status = Ref{Cint}(0)

--- a/src/libcfitsio.jl
+++ b/src/libcfitsio.jl
@@ -386,7 +386,7 @@ function fits_write_key(f::FITSFile, keyname::Compat.ASCIIString,
                         value::Union{Real,Compat.ASCIIString},
                         comment::Compat.ASCIIString)
     cvalue = isa(value,Compat.ASCIIString) ?  value :
-             isa(value,Bool) ? Cint[value] : [value]
+             isa(value,Bool) ? Cint[value] : reinterpret(UInt8, [value])
     status = Ref{Cint}(0)
     ccall((:ffpky,libcfitsio), Cint,
         (Ptr{Void},Cint,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Ref{Cint}),

--- a/test/libcfitsio.jl
+++ b/test/libcfitsio.jl
@@ -7,7 +7,7 @@ function writehealpix(filename, pixels, nside, ordering, coordsys)
         tform = "1D"
     end 
 
-    file = fits_create_file(filename)
+    file = fits_create_file("!"*filename)
     try
         fits_create_img(file, Int16, Int[])
         fits_write_date(file)
@@ -62,7 +62,7 @@ for T in (Float32, Float64)
     ordering = "NESTED"
     coordsys = "G"
 
-    filename = tempname()
+    filename = tempname() * ".fits"
     writehealpix(filename, pixels, nside, ordering, coordsys)
     @test readhealpix(filename) == (pixels, nside, ordering, coordsys)
 end

--- a/test/libcfitsio.jl
+++ b/test/libcfitsio.jl
@@ -54,18 +54,16 @@ function readhealpix(filename)
 end
 
 
-@testset "Libcfitsio" begin
-    # test reading/writing Healpix maps as FITS binary tables using the Libcfitsio interface
-    for T in (Float32, Float64)
-        nside = 4
-        npix = 12*nside*nside
-        pixels = rand(T, npix)
-        ordering = "NESTED"
-        coordsys = "G"
+# test reading/writing Healpix maps as FITS binary tables using the Libcfitsio interface
+for T in (Float32, Float64)
+    nside = 4
+    npix = 12*nside*nside
+    pixels = rand(T, npix)
+    ordering = "NESTED"
+    coordsys = "G"
 
-        filename = tempname()
-        writehealpix(filename, pixels, nside, ordering, coordsys)
-        @test readhealpix(filename) == (pixels, nside, ordering, coordsys)
-    end
+    filename = tempname()
+    writehealpix(filename, pixels, nside, ordering, coordsys)
+    @test readhealpix(filename) == (pixels, nside, ordering, coordsys)
 end
 

--- a/test/libcfitsio.jl
+++ b/test/libcfitsio.jl
@@ -1,0 +1,71 @@
+using FITSIO.Libcfitsio
+
+function writehealpix(filename, pixels, nside, ordering, coordsys)
+    if eltype(pixels) == Float32
+        tform = "1E"
+    elseif eltype(pixels) == Float64
+        tform = "1D"
+    end 
+
+    file = fits_create_file(filename)
+    try
+        fits_create_img(file, Int16, Int[])
+        fits_write_date(file)
+        fits_movabs_hdu(file, 1)
+        fits_create_binary_tbl(file, length(pixels), [("SIGNAL", tform, "")], "BINTABLE")
+        fits_write_key(file, "PIXTYPE",  "HEALPIX", "HEALPIX pixelization")
+        fits_write_key(file, "ORDERING", ordering,  "Pixel ordering scheme (either RING or NESTED)")
+        fits_write_key(file, "NSIDE",    nside,     "Resolution parameter for HEALPIX")
+        fits_write_key(file, "COORDSYS", coordsys,  "Pixelization coordinate system")
+        fits_write_comment(file, "G = galactic, E = ecliptic, C = celestial = equatorial")
+        fits_write_col(file, 1, 1, 1, pixels)
+    finally
+        fits_close_file(file)
+    end 
+end
+
+function readhealpix(filename)
+    file = fits_open_file(filename)
+    try
+        hdutype = fits_movabs_hdu(file, 2)
+        tform, tform_comment = fits_read_key_str(file, "TFORM1")
+        if tform == "1E"
+            T = Float32
+        elseif tform == "1D"
+            T = Float64
+        end
+
+        naxes, naxis_comment = fits_read_key_lng(file, "NAXIS")
+        naxis, nfound = fits_read_keys_lng(file, "NAXIS", 1, naxes)
+        nside, nside_comment = fits_read_key_lng(file, "NSIDE")
+        npix = 12*nside*nside
+
+        ordering, ordering_comment = fits_read_key_str(file, "ORDERING")
+        coordsys, coordsys_comment = fits_read_key_str(file, "COORDSYS")
+
+        pixels = zeros(T, npix)
+        fits_read_col(file, 1, 1, 1, pixels)
+
+        return pixels, nside, ordering, coordsys
+
+    finally
+        fits_close_file(file)
+    end
+end
+
+
+@testset "Libcfitsio" begin
+    # test reading/writing Healpix maps as FITS binary tables using the Libcfitsio interface
+    for T in (Float32, Float64)
+        nside = 4
+        npix = 12*nside*nside
+        pixels = rand(T, npix)
+        ordering = "NESTED"
+        coordsys = "G"
+
+        filename = tempname()
+        writehealpix(filename, pixels, nside, ordering, coordsys)
+        @test readhealpix(filename) == (pixels, nside, ordering, coordsys)
+    end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -281,3 +281,6 @@ end
 # test it parses a number as intended.
 @test FITSIO.libcfitsio_version(3.341)  === VersionNumber(3, 34, 1)
 @test FITSIO.libcfitsio_version(3.41f0) === VersionNumber(3, 41, 0)
+
+include("libcfitsio.jl")
+


### PR DESCRIPTION
I am currently in the processing of rewriting a lot of LibHealpix.jl.
One of its limitations has been that it uses the libchealpix functions
to read and write Healpix maps as FITS images. These functions only work
with Float32 values, so we were frequently discarding precision when
doing I/O with Healpix maps.

To remedy that situation I am replacing this part of the wrapper with
the FITSIO Libcfitsio interface. This makes it easy for me to port the
original C functions into Julia.

This commit adds some missing functionality that I needed to make this
work:

* wrap `fits_read_key_str`
* wrap `fits_read_key_lng`
* wrap `fits_read_keys_lng`
* wrap `fits_write_date`
* widen the signature of `fits_write_key` to accept all `Number`s

ref issue JuliaAstro/FITSIO.jl#61