### PR TITLE
Drop support for Julia 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - linux
     - osx
 julia:
-    - 0.4
     - 0.5
     - 0.6
     - nightly

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@ v0.9.0 (2017-01-24)
 ===================
 
 - Fix deprecation warnings on Julia 0.6.
-- Drop support for Julia 0.4.
+- Drop support for Julia 0.3.
 
 v0.8.4 (2016-08-09)
 ===================

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.5
 BinDeps 0.3.12
 Compat 0.17.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
     - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
     - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
     - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"

--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -123,18 +123,18 @@ end
 # could almost just use an OrderedDict for this, but we need to store
 # comments.
 type FITSHeader
-    keys::Vector{Compat.ASCIIString}
+    keys::Vector{String}
     values::Vector{Any}
-    comments::Vector{Compat.ASCIIString}
-    map::Dict{Compat.ASCIIString, Int}
+    comments::Vector{String}
+    map::Dict{String, Int}
 
-    function FITSHeader(keys::Vector{Compat.ASCIIString}, values::Vector,
-                        comments::Vector{Compat.ASCIIString})
+    function FITSHeader(keys::Vector{String}, values::Vector,
+                        comments::Vector{String})
         if ((length(keys) != length(values)) ||
             (length(keys) != length(comments)))
             error("keys, values, comments must be same length")
         end
-        map = Dict{Compat.ASCIIString, Int64}()
+        map = Dict{String, Int64}()
         for i in 1:length(keys)
           map[keys[i]] = i
         end

--- a/src/fits.jl
+++ b/src/fits.jl
@@ -55,9 +55,9 @@ function show(io::IO, f::FITS)
     else
         print(io, "HDUs: ")
 
-        names = Vector{Compat.ASCIIString}(nhdu)
-        vers = Vector{Compat.ASCIIString}(nhdu)
-        types = Vector{Compat.ASCIIString}(nhdu)
+        names = Vector{String}(nhdu)
+        vers = Vector{String}(nhdu)
+        types = Vector{String}(nhdu)
         for i = 1:nhdu
             t = fits_movabs_hdu(f.fitsfile, i)
             types[i] = (t == :image_hdu ? "Image" :
@@ -75,10 +75,10 @@ function show(io::IO, f::FITS)
         # only display version info if present
         if maximum(length, vers) > 0
             dispnames = ["Num", "Name", "Ver", "Type"]
-            dispcols = Vector{Compat.ASCIIString}[nums, names, vers, types]
+            dispcols = Vector{String}[nums, names, vers, types]
         else
             dispnames = ["Num", "Name", "Type"]
-            dispcols = Vector{Compat.ASCIIString}[nums, names, types]
+            dispcols = Vector{String}[nums, names, types]
         end
 
         show_ascii_table(io, dispnames, dispcols, 2, 6)

--- a/src/image.jl
+++ b/src/image.jl
@@ -135,7 +135,7 @@ read(hdu::ImageHDU, I::Int...) = read_internal(hdu, I...)[1]
 # Uint8, Int8, Uint16, Int16, Uint32, Int32, Int64, Float32, Float64
 function write{T}(f::FITS, data::Array{T};
                   header::Union{Void, FITSHeader}=nothing,
-                  name::Union{Void, Compat.ASCIIString}=nothing,
+                  name::Union{Void, String}=nothing,
                   ver::Union{Void, Integer}=nothing)
     fits_assert_open(f.fitsfile)
     s = size(data)
@@ -143,7 +143,7 @@ function write{T}(f::FITS, data::Array{T};
     if isa(header, FITSHeader)
         fits_write_header(f.fitsfile, header, true)
     end
-    if isa(name, Compat.ASCIIString)
+    if isa(name, String)
         fits_update_key(f.fitsfile, "EXTNAME", name)
     end
     if isa(ver, Integer)


### PR DESCRIPTION
`Compat.jl` dropped support for Julia 0.4, so it's probably time to do the same here.

Note that `String` type doesn't guarantee there are only ASCII character in the string.  If necessary, that should be tested with `isascii`.