### PR TITLE
Clear deprecation warnings in Julia 0.7

### DIFF
--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -85,10 +85,10 @@ type FITS
     hidden::Any
 
     function FITS(filename::AbstractString, mode::AbstractString="r")
-        f = (mode == "r"                     ? fits_open_file(filename, 0)   :
-             mode == "r+" && isfile(filename)? fits_open_file(filename, 1)   :
-             mode == "r+"                    ? fits_create_file(filename)    :
-             mode == "w"                     ? fits_create_file("!"*filename):
+        f = (mode == "r"                      ? fits_open_file(filename, 0)    :
+             mode == "r+" && isfile(filename) ? fits_open_file(filename, 1)    :
+             mode == "r+"                     ? fits_create_file(filename)     :
+             mode == "w"                      ? fits_create_file("!"*filename) :
              error("invalid open mode: $mode"))
 
         new(f, filename, mode, Dict{Int, HDU}(), FITSMemoryHandle(), nothing)

--- a/src/header.jl
+++ b/src/header.jl
@@ -172,7 +172,7 @@ end
 # Write header to CHDU.
 # If `clean` is true, skip writing reserved header keywords.
 function fits_write_header(f::FITSFile, hdr::FITSHeader, clean::Bool=true)
-    indices = clean? reserved_key_indices(hdr): Int[]
+    indices = clean ? reserved_key_indices(hdr) : Int[]
     for i=1:length(hdr)
         if clean && in(i, indices)
             continue

--- a/src/table.jl
+++ b/src/table.jl
@@ -93,7 +93,7 @@ function var_col_maxlen(tform::String)
 end
 
 # Helper function for getting fits tdim shape for given array
-fits_tdim(A::Array) = (ndims(A) == 1)? [1]: [size(A, i) for i=1:ndims(A)-1]
+fits_tdim(A::Array) = (ndims(A) == 1) ? [1] : [size(A, i) for i=1:ndims(A)-1]
 function fits_tdim(A::Array{String})
     n = ndims(A)
     tdim = Vector{Int}(n)
@@ -299,7 +299,7 @@ function write_internal(f::FITS, colnames::Vector{String},
     if isa(units, Void)
         tunit = C_NULL
     else
-        tunit = Ptr{UInt8}[(haskey(units, n)? pointer(units[n]): C_NULL)
+        tunit = Ptr{UInt8}[(haskey(units, n) ? pointer(units[n]) : C_NULL)
                            for n in colnames]
     end
 


### PR DESCRIPTION
Only warnings about `type` keyword are issued now, but this isn't supported in `Compat.jl`.