### PR TITLE
Make Documenter build successfully

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,4 +12,6 @@ makedocs(
 deploydocs(
     repo = "github.com/JuliaAstro/FITSIO.jl.git",
     target = "build",
+    deps   = nothing,
+    julia  = "0.4",
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,6 @@ makedocs(
 deploydocs(
     repo = "github.com/JuliaAstro/FITSIO.jl.git",
     target = "build",
-    deps   = nothing,
-    julia  = "0.4",
+    deps = Deps.pip("mkdocs", "python-markdown-math"),
+    julia  = "0.6",
 )

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,24 @@
+site_name:        FITSIO.jl
+repo_url:         https://github.com/JuliaAstro/FITSIO.jl
+site_description: Flexible Image Transport System (FITS) support for Julia
+site_author:      Kyle Barbary
+
+theme: cinder
+
+extra_css:
+  - assets/Documenter.css
+
+extra_javascript:
+  - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
+  - assets/mathjaxhelper.js
+
+markdown_extensions:
+  - extra
+  - tables
+  - fenced_code
+  - mdx_math
+
+docs_dir: 'build'
+
+pages:
+  - Home: index.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name:        FITSIO.jl
 repo_url:         https://github.com/JuliaAstro/FITSIO.jl
 site_description: Flexible Image Transport System (FITS) support for Julia
-site_author:      Kyle Barbary
+site_author:      FITSIO.jl developers
 
 theme: cinder
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,158 @@
+# FITSIO.jl
+
+A [Julia](http://julialang.org) package for reading and writing Flexible Image Transport System (FITS) files, based on the [cfitsio](http://heasarc.gsfc.nasa.gov/fitsio/) library.
+
+The interface is inspired by Erin Sheldon's [fitsio](https://github.com/esheldon/fitsio) Python package.
+
+## Installation
+
+FITSIO is available for Julia 0.6 and later versions, and can be installed with [Julia](https://github.com/julialang/julia.jl)'s built-in package manager. In a Julia session run the command
+
+```julia
+julia> Pkg.update()
+julia> Pkg.add("FITSIO.jl")
+```
+
+On linux or OS X, if it isn't already installed on your system,
+the cfitsio library is automatically downloaded and compiled
+(in your Julia packages directory). On Windows, a compiled dll will be
+downloaded.
+
+## Usage
+
+To open an existing file for reading:
+```julia
+julia> using FITSIO
+
+julia> f = FITS("file.fits")
+File: file.fits
+Mode: r
+HDUs: extnum extname  exttype         
+       1             image_hdu       
+       2             binary_table
+```
+(At the REPL, information about the file contents is shown.)
+
+A FITS file consists of one or more header-data units (HDUs), concatenated one after the other. The `FITS` object therefore is represented as a collection of these HDUs.
+
+Get information about the first HDU:
+```julia
+julia> f[1]
+File: file.fits
+Extension: 1
+Type: IMAGE
+image info:
+  bitpix: -64
+  size: (800,800)
+```
+
+Iterate over HDUs in the file:
+```julia
+julia> for hdu in f; println(typeof(hdu)); end
+FITSIO.ImageHDU
+FITSIO.TableHDU
+```
+
+Each HDU can contain image data, or table data (either binary or
+ASCII-formatted). For image extensions, get the size of the image
+without reading it:
+```julia
+julia> ndims(f[1])
+    2
+
+julia> size(f[1])
+(800,800)
+
+julia> size(f[1], 2)
+800
+```
+
+Read an image from disk:
+```julia
+julia> data = read(f[1]);  # read an image from disk
+
+julia> data = read(f[1], :, 790:end);  # read just a subset of image
+```
+
+Show info about a binary table:
+```julia
+julia> f[2]
+File: file.fits
+Extension: 2
+Type: BINARY TABLE
+Rows: 20
+Columns:
+    col2 (5A)
+    col1 (1K)
+```
+
+Read a column from the table:
+```julia
+ julia> data = read(f[2], "col1")
+```
+
+Read the entire header into memory and get values from it:
+```julia
+julia> header = read_header(f[1]);  # read the entire header from disk
+
+julia> length(header)  # total number of records in header
+17
+
+julia> haskey(header, "NAXIS1")  # check if a key exists
+true
+
+julia> header["NAXIS1"]  # get value by keyword
+800
+
+julia> header[4]  # get value by position
+800
+
+julia> get_comment(header, "NAXIS")  # get comment for a given keyword
+"length of data axis 1"
+```
+
+Read just a single header record without reading the entire header:
+```julia
+julia> read_key(f[1], 4)  # by position
+("NAXIS1",800,"length of data axis 1")
+
+julia> read_key(f[1], "NAXIS1")  # read by keyword
+(800,"length of data axis 1")
+```
+
+Manipulate a header in memory:
+```julia
+julia> header["NEWKEY"] = 10  # change or add a keyword
+
+julia> set_comment!(header, "NEWKEY", "this is a comment")
+```
+
+Close the file:
+```julia
+julia> close(f)
+```
+(`FITS` objects are also closed automatically when garbage collected.)
+
+Open a new file for writing:
+```julia
+julia> f = FITS("newfile.fits", "w");
+```
+The second argument can be `"r"` (read-only; default), `"r+"`
+(read-write) or `"w"` (write). In "write" mode, any existing file of
+the same name is overwritten.
+
+Write an image to the file:
+```julia
+julia> data = reshape([1:100], 5, 20);
+
+julia> write(f, data)  # Write a new image extension with the data
+```
+To write some header keywords in the new extension, pass a
+`FITSHeader` instance as a keyword: `write(f, data; header=header)`
+
+Write a table to the file:
+```julia
+julia> data = ["col1"=>[1., 2., 3.], "col2"=>[1, 2, 3]];
+
+julia> write(f, data)  # write a new binary table to a new extension
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,7 +13,7 @@ julia> Pkg.update()
 julia> Pkg.add("FITSIO.jl")
 ```
 
-On linux or OS X, if it isn't already installed on your system,
+On Linux or OS X, if it isn't already installed on your system,
 the cfitsio library is automatically downloaded and compiled
 (in your Julia packages directory). On Windows, a compiled dll will be
 downloaded.
@@ -27,11 +27,12 @@ julia> using FITSIO
 julia> f = FITS("file.fits")
 File: file.fits
 Mode: r
-HDUs: extnum extname  exttype         
-       1             image_hdu       
+HDUs: extnum extname  exttype
+       1             image_hdu
        2             binary_table
 ```
 (At the REPL, information about the file contents is shown.)
+
 
 A FITS file consists of one or more header-data units (HDUs), concatenated one after the other. The `FITS` object therefore is represented as a collection of these HDUs.
 
@@ -46,12 +47,14 @@ image info:
   size: (800,800)
 ```
 
+
 Iterate over HDUs in the file:
 ```julia
 julia> for hdu in f; println(typeof(hdu)); end
 FITSIO.ImageHDU
 FITSIO.TableHDU
 ```
+
 
 Each HDU can contain image data, or table data (either binary or
 ASCII-formatted). For image extensions, get the size of the image
@@ -67,12 +70,14 @@ julia> size(f[1], 2)
 800
 ```
 
+
 Read an image from disk:
 ```julia
 julia> data = read(f[1]);  # read an image from disk
 
 julia> data = read(f[1], :, 790:end);  # read just a subset of image
 ```
+
 
 Show info about a binary table:
 ```julia
@@ -86,10 +91,12 @@ Columns:
     col1 (1K)
 ```
 
+
 Read a column from the table:
 ```julia
  julia> data = read(f[2], "col1")
 ```
+
 
 Read the entire header into memory and get values from it:
 ```julia
@@ -111,6 +118,7 @@ julia> get_comment(header, "NAXIS")  # get comment for a given keyword
 "length of data axis 1"
 ```
 
+
 Read just a single header record without reading the entire header:
 ```julia
 julia> read_key(f[1], 4)  # by position
@@ -120,6 +128,7 @@ julia> read_key(f[1], "NAXIS1")  # read by keyword
 (800,"length of data axis 1")
 ```
 
+
 Manipulate a header in memory:
 ```julia
 julia> header["NEWKEY"] = 10  # change or add a keyword
@@ -127,11 +136,13 @@ julia> header["NEWKEY"] = 10  # change or add a keyword
 julia> set_comment!(header, "NEWKEY", "this is a comment")
 ```
 
+
 Close the file:
 ```julia
 julia> close(f)
 ```
 (`FITS` objects are also closed automatically when garbage collected.)
+
 
 Open a new file for writing:
 ```julia
@@ -141,6 +152,7 @@ The second argument can be `"r"` (read-only; default), `"r+"`
 (read-write) or `"w"` (write). In "write" mode, any existing file of
 the same name is overwritten.
 
+
 Write an image to the file:
 ```julia
 julia> data = reshape([1:100], 5, 20);
@@ -149,6 +161,7 @@ julia> write(f, data)  # Write a new image extension with the data
 ```
 To write some header keywords in the new extension, pass a
 `FITSHeader` instance as a keyword: `write(f, data; header=header)`
+
 
 Write a table to the file:
 ```julia


### PR DESCRIPTION
#77 doesn't build docs due to an error cause by missing `mkdocs.yml` file. Additionally, in the same PR a lack of content for `index.md` was pointed out. PR to resolve the same.
