### PR TITLE
Do not print newline at the end of show methods

### DIFF
--- a/src/fits.jl
+++ b/src/fits.jl
@@ -19,13 +19,13 @@ function show_ascii_table(io, names, cols, spaces=2, indent=0)
     for i = 1:ncols
         print(io, rpad(names[i], lengths[i]))
     end
-    print(io, "\n")
+    println(io)
     for j = 1:nrows
         print(io, " "^indent)
         for i=1:ncols
             print(io, rpad(cols[i][j], lengths[i]))
         end
-        print(io, "\n")
+        j != nrows && println(io)
     end
 end
 

--- a/src/header.jl
+++ b/src/header.jl
@@ -336,14 +336,10 @@ end
 
 # Display the header
 function show(io::IO, hdr::FITSHeader)
-    for i=1:length(hdr)
-        cl = length(hdr.comments[i])
+    n = length(hdr)
+    for i=1:n
         if hdr.keys[i] == "COMMENT" || hdr.keys[i] == "HISTORY"
-            if cl > 71
-                @printf io "%s %s\n" hdr.keys[i] hdr.comments[i][1:71]
-            else
-                @printf io "%s %s\n" hdr.keys[i] hdr.comments[i]
-            end
+            @printf io "%s %s" hdr.keys[i] hdr.comments[i][1:min(71, end)]
         else
             @printf io "%-8s" hdr.keys[i]
             if hdr.values[i] === nothing
@@ -355,14 +351,10 @@ function show(io::IO, hdr::FITSHeader)
                 rc = length(val) <= 20 ? 50 : 70 - length(val)
             end
 
-            if cl > 0
-                if cl > rc - 3
-                    @printf io " / %s" hdr.comments[i][1:rc-3]
-                else
-                    @printf io " / %s" hdr.comments[i]
-                end
+            if length(hdr.comments[i]) > 0
+                @printf io " / %s" hdr.comments[i][1:min(rc-3, end)]
             end
-            print(io, "\n")
         end
+        i != n && println(io)
     end
 end

--- a/src/image.jl
+++ b/src/image.jl
@@ -21,8 +21,7 @@ function show(io::IO, hdu::ImageHDU)
     HDU: $(hdu.ext)$(fits_get_ext_info_string(hdu.fitsfile))
     Type: Image
     Datatype: $datainfo
-    Datasize: $(tuple(sz...))
-    """)
+    Datasize: $(tuple(sz...))""")
 end
 
 # Get image dimensions

--- a/src/table.jl
+++ b/src/table.jl
@@ -184,7 +184,7 @@ function show(io::IO, hdu::TableHDU)
         Vector{String}[colnames, colrowsizes, coltypes, coltforms],
         2, 9)
     if showlegend
-        print(io, "\n         (*) = variable-length column\n")
+        print(io, "\n\n         (*) = variable-length column")
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,14 +35,16 @@ using Base.Test
 
         @test_throws ErrorException f[100]
 
+        # Test representation
+        @test repr(f)[end-17:end] == "9          Image  "
+        @test repr(f[1])[1:6] == "File: "
+
         # test iteration
         for hdu in f
             @test size(hdu) == (5, 20)
         end
     end
-    if isfile(fname)
-        rm(fname)
-    end
+    rm(fname, force=true)
 
     # copy_section()
     fname1 = tempname() * ".fits"
@@ -99,6 +101,8 @@ end
         @test eltype(outcol) == eltype(incol)
     end
 
+    # Test representation
+    @test repr(f[2])[end-38:end] == "\n\n         (*) = variable-length column"
 
     ## ASCII tables
 
@@ -153,8 +157,7 @@ INTKEY  =                    1
 BOOLKEY =                    T / boolean keyword
 STRKEY  =       'string value' / string value
 COMMENT this is a comment
-HISTORY this is a history
-"""
+HISTORY this is a history"""
 
     inhdr["INTKEY"] = 2  # test setting by key
     inhdr[1] = 2.0  # test settting by index


### PR DESCRIPTION
Usually `show` methods don't add a newline at the end, as the Julia REPL automatically prints it.

There are no tests, should I add them?