### PR TITLE
edited possible error in install instructions

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,7 +15,7 @@ built-in package manager. In a Julia session run the command
 
 ```julia
 julia> Pkg.update()
-julia> Pkg.add("FITSIO.jl")
+julia> Pkg.add("FITSIO")
 ```
 
 On Linux or OS X, if it isn't already installed on your system,


### PR DESCRIPTION
Trying to install FITSIO on a clean debian system running Julia Version 0.4.7 I had to remove the .jl extension when adding the package.