### PR TITLE
Drop support for unmaintained Julia 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - linux
     - osx
 julia:
-    - 0.5
     - 0.6
     - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 BinDeps 0.3.12
-Compat 0.29.0
+Compat 0.41.0
 @osx Homebrew

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
     - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
     - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
     - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"

--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -2,7 +2,7 @@ isdefined(Base, :__precompile__) && __precompile__()
 
 module FITSIO
 
-using Compat
+using Compat.Printf
 
 export FITS,
        HDU,
@@ -49,19 +49,19 @@ import .Libcfitsio: libcfitsio,
                     TYPE_FROM_BITPIX
 
 # HDU Types
-@compat abstract type HDU end
+abstract type HDU end
 
-type ImageHDU <: HDU
+mutable struct ImageHDU <: HDU
     fitsfile::FITSFile
     ext::Int
 end
 
-type TableHDU <: HDU
+mutable struct TableHDU <: HDU
     fitsfile::FITSFile
     ext::Int
 end
 
-type ASCIITableHDU <: HDU
+mutable struct ASCIITableHDU <: HDU
     fitsfile::FITSFile
     ext::Int
 end
@@ -100,7 +100,7 @@ supports the following operations:
   ```
 """
 FITS
-type FITS
+mutable struct FITS
     fitsfile::FITSFile
     filename::AbstractString
     mode::AbstractString
@@ -158,7 +158,7 @@ if it was created by `read_header(::HDU)`.  You can, however, write a
 `FITSHeader` to a file using the `write(::FITS, ...)` methods that
 append a new HDU to a file.
 """
-type FITSHeader
+mutable struct FITSHeader
     keys::Vector{String}
     values::Vector{Any}
     comments::Vector{String}

--- a/src/libcfitsio.jl
+++ b/src/libcfitsio.jl
@@ -168,7 +168,7 @@ end
 # -----------------------------------------------------------------------------
 # FITSFile type
 
-type FITSFile
+mutable struct FITSFile
     ptr::Ptr{Void}
 
     function FITSFile(ptr::Ptr{Void})
@@ -180,7 +180,7 @@ end
 
 # FITS wants to be able to update the ptr, so keep them
 # in a mutable struct
-type FITSMemoryHandle
+mutable struct FITSMemoryHandle
     ptr::Ptr{Void}
     size::Csize_t
 end


### PR DESCRIPTION
There are still some errors on Julia 0.7 that need to be addressed.