### PR TITLE
Add method to get colum names in FITS tables

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -40,6 +40,7 @@ copy_section
 write(::FITS, ::Dict{String})
 write(::FITS, ::Vector{String}, ::Vector)
 read(::TableHDU, ::String)
+FITSIO.colnames(hdu::Union{ASCIITableHDU,TableHDU})
 ```
 
 ## Miscellaneous

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,7 +9,7 @@ The interface is inspired by Erin Sheldon's
 
 ## Installation
 
-FITSIO is available for Julia 0.5 and later versions, and can be
+FITSIO is available for Julia 0.6 and later versions, and can be
 installed with [Julia](https://github.com/julialang/julia.jl)'s
 built-in package manager. In a Julia session run the command
 

--- a/src/table.jl
+++ b/src/table.jl
@@ -178,6 +178,11 @@ function columns_names_tforms(hdu::Union{ASCIITableHDU,TableHDU})
     return colnames, coltforms, ncols, nrows
 end
 
+"""
+    colnames(hdu=Union{ASCIITableHDU,TableHDU})
+
+Return a vector with the names of the columns in the `hdu` table.
+"""
 colnames(hdu::Union{ASCIITableHDU,TableHDU}) = columns_names_tforms(hdu)[1]
 
 function show(io::IO, hdu::TableHDU)
@@ -345,8 +350,8 @@ end
 
 Same as `write(f::FITS, data::Dict; ...)` but providing column names
 and column data as a separate arrays. This is useful for specifying
-the order of the columns. Column names must be `Array{ASCIIString}`
-and column data must be an array of arrays.
+the order of the columns. Column names must be `Vector{String}`
+and column data must be a vector of arrays.
 """
 function write(f::FITS, colnames::Vector{String}, coldata::Vector;
                units=nothing, header=nothing, hdutype=TableHDU,
@@ -365,11 +370,11 @@ end
 Create a new table extension and write data to it. If the FITS file is
 currently empty then a dummy primary array will be created before
 appending the table extension to it. `data` should be a dictionary
-with ASCIIString keys (giving the column names) and Array values
+with String keys (giving the column names) and Array values
 (giving data to write to each column). The following types are
 supported in binary tables: `Uint8`, `Int8`, `Uint16`, `Int16`,
-`Uint32`, `Int32`, `Int64`, `Float32`, `Float64`, `Complex64`,
-`Complex128`, `ASCIIString`, `Bool`.
+`Uint32`, `Int32`, `Int64`, `Float32`, `Float64`, `Complex{Float32}`,
+`Complex{Float64}`, `String`, `Bool`.
 
 Optional inputs:
 
@@ -388,7 +393,7 @@ Optional inputs:
     arrays of different lengths. They can potentially save diskspace
     when the rows of a column vary greatly in length, as the column
     data is all written to a contiguous heap area at the end of the
-    table. Only column data of type `Vector{ASCIIString}` or types
+    table. Only column data of type `Vector{String}` or types
     such as `Vector{Vector{UInt8}}` can be written as variable
     length columns. In the second case, ensure that the column data
     type is a *leaf type*. That is, the type cannot be

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -121,11 +121,17 @@ end
     expected_type = Dict(Int16=>Int32, Int32=>Int32,
                          Float32=>Float64, Float64=>Float64,
                          String=>String)
+    colnames = FITSIO.colnames(f[3])
     for (colname, incol) in indata
         outcol = read(f[3], colname)  # table is in extension 3
         @test outcol == incol
         @test eltype(outcol) == expected_type[eltype(incol)]
+        @test colname in colnames
     end
+    # test show/repr on ASCIITableHDU by checking that a couple lines are what we expect
+    lines = split(repr(f[3]), "\n")
+    @test lines[4] == "Rows: 20"
+    @test lines[6] == "         col3  Float64  E26.17  "
     close(f)
     rm(fname, force=true)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,10 +94,12 @@ end
     write(f, indata; varcols=["vcol1", "vcol2"])
 
     # test reading
+    colnames = FITSIO.colnames(f[2])
     for (colname, incol) in indata
         outcol = read(f[2], colname)  # table is in extension 2 (1 = primary hdr)
         @test outcol == incol
         @test eltype(outcol) == eltype(incol)
+        @test colname in colnames
     end
 
     # Test representation


### PR DESCRIPTION
Here is my take to close #93.

A couple of comments:
* I'm not sure whether the `colnames` function should be exported
* There are no test about showing an `ASCIITable`.  Why `f[3]` in the "Tables" test set can't be shown?