### PR TITLE
Update FITSIO.jl to work with Julia 0.6, 0.7 and 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ os:
     - osx
 julia:
     - 0.6
+    - 0.7
+    - 1.0
     - nightly
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ addons:
     - libcfitsio3
 #script: # use the default script which is equivalent to the following
 #    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#    - julia -e 'Pkg.clone(pwd()); Pkg.build("FITSIO"); Pkg.test("FITSIO"; coverage=true)';
+#    - julia -e 'VERSION >= v"0.7.0-DEV.5183" && using Pkg; Pkg.clone(pwd()); Pkg.build("FITSIO"); Pkg.test("FITSIO"; coverage=true)';
 after_success:
-    - julia -e 'Pkg.add("Documenter")'
-    - julia -e 'cd(Pkg.dir("FITSIO")); include(joinpath("docs", "make.jl"))'
-    - julia -e 'cd(Pkg.dir("FITSIO")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+    - julia -e 'VERSION >= v"0.7.0-DEV.5183" && using Pkg; Pkg.add("Documenter")'
+    - julia -e 'VERSION >= v"0.7.0-DEV.5183" && using Pkg; cd(Pkg.dir("FITSIO")); include(joinpath("docs", "make.jl"))'
+    - julia -e 'VERSION >= v"0.7.0-DEV.5183" && using Pkg; cd(Pkg.dir("FITSIO")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
 BinaryProvider 0.3.0
-Compat 0.41.0
+Compat 0.62.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
 build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "isdefined(Base,:versioninfo) && versioninfo(); Pkg.clone(pwd(), \"FITSIO\"); Pkg.build(\"FITSIO\")"
+  - C:\projects\julia\bin\julia -e "isdefined(Base, :versioninfo) && versioninfo(); VERSION >= v"0.7.0-DEV.5183" && using Pkg; Pkg.clone(pwd(), \"FITSIO\"); Pkg.build(\"FITSIO\")"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"FITSIO\")"
+  - C:\projects\julia\bin\julia --check-bounds=yes -e "VERSION >= v"0.7.0-DEV.5183" && using Pkg; Pkg.test(\"FITSIO\")"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
 build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "isdefined(Base, :versioninfo) && versioninfo(); VERSION >= v"0.7.0-DEV.5183" && using Pkg; Pkg.clone(pwd(), \"FITSIO\"); Pkg.build(\"FITSIO\")"
+  - C:\projects\julia\bin\julia -e "isdefined(Base, :versioninfo) && versioninfo(); VERSION >= v\"0.7.0-DEV.5183\" && using Pkg; Pkg.clone(pwd(), \"FITSIO\"); Pkg.build(\"FITSIO\")"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "VERSION >= v"0.7.0-DEV.5183" && using Pkg; Pkg.test(\"FITSIO\")"
+  - C:\projects\julia\bin\julia --check-bounds=yes -e "VERSION >= v\"0.7.0-DEV.5183\" && using Pkg; Pkg.test(\"FITSIO\")"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,10 @@ environment:
   matrix:
     - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
     - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
+    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/1.0/julia-1.0-latest-win32.exe"
+    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0-latest-win64.exe"
     - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
     - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
@@ -28,8 +32,7 @@ install:
 build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"FITSIO\"); Pkg.build(\"FITSIO\")"
+  - C:\projects\julia\bin\julia -e "isdefined(Base,:versioninfo) && versioninfo(); Pkg.clone(pwd(), \"FITSIO\"); Pkg.build(\"FITSIO\")"
 
 test_script:
   - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"FITSIO\")"

--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -2,8 +2,6 @@ isdefined(Base, :__precompile__) && __precompile__()
 
 module FITSIO
 
-using Compat.Printf
-
 export FITS,
        HDU,
        ImageHDU,
@@ -26,13 +24,19 @@ import Base: getindex,
              close,
              ndims,
              size,
-             endof,
              haskey,
              keys,
-             values,
-             start,
-             next,
-             done
+             values
+
+# Deal with compatibility issues.
+using Compat
+using Compat.Printf
+import Compat: lastindex
+@static if isdefined(Base, :iterate)
+    import Base: iterate
+else
+    import Base: start, next, done
+end
 
 # Libcfitsio submodule
 include("libcfitsio.jl")

--- a/src/fits.jl
+++ b/src/fits.jl
@@ -75,10 +75,10 @@ function show(io::IO, f::FITS)
                         t == :binary_table ? "Table" :
                         t == :ascii_table ? "ASCIITable" :
                         error("unknown HDU type"))
-            nname = fits_try_read_extname(f.fitsfile)
-            names[i] = get(nname, "")
-            nver = fits_try_read_extver(f.fitsfile)
-            vers[i] = isnull(nver) ? "" : string(get(nver))
+            name = fits_try_read_extname(f.fitsfile)
+            names[i] = (name === nothing ? "" : name)
+            ver = fits_try_read_extver(f.fitsfile)
+            vers[i] = (ver === nothing ? "" : string(ver))
         end
 
         nums = [string(i) for i=1:nhdu]

--- a/src/fits.jl
+++ b/src/fits.jl
@@ -43,7 +43,7 @@ lastindex(f::FITS) = length(f)
 
 # Iteration
 @static if isdefined(Base,:iterate)
-    iterate(f::FITS) = 1
+    iterate(f::FITS) = iterate(f, 1)
     iterate(f::FITS, state) =
         (state ≤ length(f) ? (f[state], state + 1) : nothing)
 else

--- a/src/fits.jl
+++ b/src/fits.jl
@@ -39,12 +39,18 @@ function length(f::FITS)
     Int(fits_get_num_hdus(f.fitsfile))
 end
 
-endof(f::FITS) = length(f)
+lastindex(f::FITS) = length(f)
 
 # Iteration
-start(f::FITS) = 1
-next(f::FITS, state) = (f[state], state + 1)
-done(f::FITS, state) = state > length(f)
+@static if isdefined(Base,:iterate)
+    iterate(f::FITS) = 1
+    iterate(f::FITS, state) =
+        (state ≤ length(f) ? (f[state], state + 1) : nothing)
+else
+    start(f::FITS) = 1
+    next(f::FITS, state) = (f[state], state + 1)
+    done(f::FITS, state) = state > length(f)
+end
 
 function show(io::IO, f::FITS)
     fits_assert_open(f.fitsfile)
@@ -60,9 +66,9 @@ function show(io::IO, f::FITS)
     else
         print(io, "HDUs: ")
 
-        names = Vector{String}(nhdu)
-        vers = Vector{String}(nhdu)
-        types = Vector{String}(nhdu)
+        names = Vector{String}(undef, nhdu)
+        vers = Vector{String}(undef, nhdu)
+        types = Vector{String}(undef, nhdu)
         for i = 1:nhdu
             t = fits_movabs_hdu(f.fitsfile, i)
             types[i] = (t == :image_hdu ? "Image" :

--- a/src/header.jl
+++ b/src/header.jl
@@ -200,7 +200,7 @@ function reserved_key_indices(hdr::FITSHeader)
     # Note that this removes anything matching NAXIS\d regardless of # of axes.
     if in("NAXIS", hdr.keys)
         for i=1:nhdr
-            if ismatch(r"^NAXIS\d*$", hdr.keys[i])
+            if occursin(r"^NAXIS\d*$", hdr.keys[i])
                 push!(indices, i)
             end
         end
@@ -208,10 +208,10 @@ function reserved_key_indices(hdr::FITSHeader)
 
     if in("ZNAXIS", hdr.keys)
         for i=1:nhdr
-            if (ismatch(r"^ZNAXIS\d*$", hdr.keys[i]) ||
-                ismatch(r"^ZTILE\d*$", hdr.keys[i]) ||
-                ismatch(r"^ZNAME\d*$", hdr.keys[i]) ||
-                ismatch(r"^ZVAL\d*$", hdr.keys[i]))
+            if (occursin(r"^ZNAXIS\d*$", hdr.keys[i]) ||
+                occursin(r"^ZTILE\d*$", hdr.keys[i]) ||
+                occursin(r"^ZNAME\d*$", hdr.keys[i]) ||
+                occursin(r"^ZVAL\d*$", hdr.keys[i]))
                 push!(indices, i)
             end
         end
@@ -225,7 +225,7 @@ function reserved_key_indices(hdr::FITSHeader)
                        r"^TDMAX\d*$", r"^TDESC\d*$", r"^TROTA\d*$",
                        r"^TRPIX\d*$", r"^TRVAL\d*$", r"^TDELT\d*$",
                        r"^TCUNI\d*$", r"^TFIELDS$"]
-                if ismatch(re, hdr.keys[i])
+                if occursin(re, hdr.keys[i])
                     push!(indices, i)
                 end
             end

--- a/src/image.jl
+++ b/src/image.jl
@@ -64,9 +64,9 @@ Get total number of pixels in image (product of ``size(hdu)``).
 """
 length(hdu::ImageHDU) = prod(size(hdu))
 
-# `endof` is needed so that hdu[:] can throw DimensionMismatch
+# `lastindex` is needed so that hdu[:] can throw DimensionMismatch
 # when ndim != 1, rather than no method.
-endof(hdu::ImageHDU) = length(hdu::ImageHDU)
+lastindex(hdu::ImageHDU) = length(hdu::ImageHDU)
 
 # Read a full image from an HDU
 """
@@ -82,7 +82,7 @@ function read(hdu::ImageHDU)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
     sz = fits_get_img_size(hdu.fitsfile)
     bitpix = fits_get_img_equivtype(hdu.fitsfile)
-    data = Array{TYPE_FROM_BITPIX[bitpix]}(sz...)
+    data = Array{TYPE_FROM_BITPIX[bitpix]}(undef, sz...)
     fits_read_pix(hdu.fitsfile, data)
     data
 end
@@ -90,15 +90,15 @@ end
 # _checkbounds methods copied from Julia v0.4 Base.
 _checkbounds(sz, i::Integer) = 1 <= i <= sz
 _checkbounds(sz, i::Colon) = true
-_checkbounds(sz, r::Range{Int}) =
+_checkbounds(sz, r::AbstractRange{Int}) =
     (isempty(r) || (minimum(r) >= 1 && maximum(r) <= sz))
 
 # helper functions for constructing cfitsio indexing vectors in read(hdu, ...)
-_first(i::Union{Integer, Range}) = first(i)
+_first(i::Union{Integer, AbstractRange}) = first(i)
 _first(::Colon) = 1
-_last(sz, i::Union{Integer, Range}) = last(i)
+_last(sz, i::Union{Integer, AbstractRange}) = last(i)
 _last(sz, ::Colon) = sz
-_step(r::Range) = step(r)
+_step(r::AbstractRange) = step(r)
 _step(::Union{Integer, Colon}) = 1
 
 # Shape of array to create for read(hdu, ...), dropping trailing
@@ -107,16 +107,16 @@ _step(::Union{Integer, Colon}) = 1
 @inline _index_shape(sz, I...) = _index_shape_dim(sz, 1, I...)
 _index_shape_dim(sz, dim, I::Integer...) = ()
 _index_shape_dim(sz, dim, ::Colon) = (sz[dim],)
-_index_shape_dim(sz, dim, r::Range) = (length(r),)
+_index_shape_dim(sz, dim, r::AbstractRange) = (length(r),)
 @inline _index_shape_dim(sz, dim, ::Colon, I...) =
     tuple(sz[dim], _index_shape_dim(sz, dim+1, I...)...)
 @inline _index_shape_dim(sz, dim, ::Integer, I...) =
     _index_shape_dim(sz, dim+1, I...)
-@inline _index_shape_dim(sz, dim, r::Range, I...) =
+@inline _index_shape_dim(sz, dim, r::AbstractRange, I...) =
     tuple(length(r), _index_shape_dim(sz, dim+1, I...)...)
 
 # Read a subset of an ImageHDU
-function read_internal(hdu::ImageHDU, I::Union{Range{Int}, Integer, Colon}...)
+function read_internal(hdu::ImageHDU, I::Union{AbstractRange{Int}, Integer, Colon}...)
     fits_assert_open(hdu.fitsfile)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
     sz = fits_get_img_size(hdu.fitsfile)
@@ -138,14 +138,14 @@ function read_internal(hdu::ImageHDU, I::Union{Range{Int}, Integer, Colon}...)
 
     # construct output array
     bitpix = fits_get_img_equivtype(hdu.fitsfile)
-    data = Array{TYPE_FROM_BITPIX[bitpix]}(_index_shape(sz, I...))
+    data = Array{TYPE_FROM_BITPIX[bitpix]}(undef, _index_shape(sz, I...))
 
     fits_read_subset(hdu.fitsfile, firsts, lasts, steps, data)
     data
 end
 
 # general method and version that returns a single value rather than 0-d array
-read(hdu::ImageHDU, I::Union{Range{Int}, Int, Colon}...) =
+read(hdu::ImageHDU, I::Union{AbstractRange{Int}, Int, Colon}...) =
     read_internal(hdu, I...)
 read(hdu::ImageHDU, I::Int...) = read_internal(hdu, I...)[1]
 
@@ -159,10 +159,10 @@ following array element types are supported: `UInt8`, `Int8`,
 `Float64`. If a `FITSHeader` object is passed as the `header` keyword
 argument, the header will also be added to the new HDU.
 """
-function write{T}(f::FITS, data::Array{T};
-                  header::Union{Void, FITSHeader}=nothing,
-                  name::Union{Void, String}=nothing,
-                  ver::Union{Void, Integer}=nothing)
+function write(f::FITS, data::Array{T};
+               header::Union{Nothing, FITSHeader}=nothing,
+               name::Union{Nothing, String}=nothing,
+               ver::Union{Nothing, Integer}=nothing) where {T}
     fits_assert_open(f.fitsfile)
     s = size(data)
     fits_create_img(f.fitsfile, T, [s...])
@@ -215,7 +215,7 @@ Same as above but only copy odd columns in y:
 copy_section(hdu, f, 1:200, 1:2:200)
 ```
 """
-function copy_section(hdu::ImageHDU, dest::FITS, r::Range{Int}...)
+function copy_section(hdu::ImageHDU, dest::FITS, r::AbstractRange{Int}...)
     fits_assert_open(hdu.fitsfile)
     fits_assert_open(dest.fitsfile)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)

--- a/src/libcfitsio.jl
+++ b/src/libcfitsio.jl
@@ -118,6 +118,15 @@ export FITSFile,
        fits_write_record,
        fits_write_tdim
 
+# Deal with compatibility issues.
+using Compat
+@static if VERSION < v"0.7.0-DEV.2562"
+    @inline function Base.finalizer(func::Function, obj)
+        finalizer(obj, func)
+        return obj
+    end
+end
+
 if isfile(joinpath(dirname(@__FILE__),"..","deps","deps.jl"))
     include("../deps/deps.jl")
 else
@@ -152,8 +161,8 @@ for (T, code) in ((UInt8,       11),
                   (Int64,       81),
                   (Float32,     42),
                   (Float64,     82),
-                  (Complex64,   83),
-                  (Complex128, 163))
+                  (ComplexF32,  83),
+                  (ComplexF64, 163))
     @eval cfitsio_typecode(::Type{$T}) = Cint($code)
 end
 
@@ -169,19 +178,15 @@ end
 # FITSFile type
 
 mutable struct FITSFile
-    ptr::Ptr{Void}
+    ptr::Ptr{Cvoid}
 
-    function FITSFile(ptr::Ptr{Void})
-        f = new(ptr)
-        finalizer(f, fits_close_file)
-        f
-    end
+    FITSFile(ptr::Ptr{Cvoid}) = finalizer(fits_close_file, new(ptr))
 end
 
 # FITS wants to be able to update the ptr, so keep them
 # in a mutable struct
 mutable struct FITSMemoryHandle
-    ptr::Ptr{Void}
+    ptr::Ptr{Cvoid}
     size::Csize_t
 end
 FITSMemoryHandle() = FITSMemoryHandle(C_NULL, 0)
@@ -196,8 +201,8 @@ function fits_assert_open(f::FITSFile)
 end
 
 function fits_get_errstatus(status::Cint)
-    msg = Vector{UInt8}(31)
-    ccall((:ffgerr,libcfitsio), Void, (Cint,Ptr{UInt8}), status, msg)
+    msg = Vector{UInt8}(undef, 31)
+    ccall((:ffgerr,libcfitsio), Cvoid, (Cint,Ptr{UInt8}), status, msg)
     unsafe_string(pointer(msg))
 end
 
@@ -211,7 +216,7 @@ end
 fits_assert_isascii(str::String) =
     !isascii(str) && error("FITS file format accepts ASCII strings only")
 
-fits_get_version() = ccall((:ffvers, libcfitsio), Cfloat, (Ptr{Cfloat},), &0.)
+fits_get_version() = ccall((:ffvers, libcfitsio), Cfloat, (Ref{Cfloat},), 0.0)
 
 # -----------------------------------------------------------------------------
 # file access & info functions
@@ -222,9 +227,9 @@ fits_get_version() = ccall((:ffvers, libcfitsio), Cfloat, (Ptr{Cfloat},), &0.)
 Create and open a new empty output `FITSFile`.
 """
 function fits_create_file(filename::AbstractString)
-    ptr = Ref{Ptr{Void}}()
+    ptr = Ref{Ptr{Cvoid}}()
     status = Ref{Cint}(0)
-    ccall((:ffinit,libcfitsio), Cint, (Ref{Ptr{Void}},Ptr{UInt8},Ref{Cint}),
+    ccall((:ffinit,libcfitsio), Cint, (Ref{Ptr{Cvoid}},Ptr{UInt8},Ref{Cint}),
           ptr, filename, status)
     fits_assert_ok(status[], filename)
     FITSFile(ptr[])
@@ -274,10 +279,10 @@ for (a,b) in ((:fits_open_data, "ffdopn"),
               (:fits_open_table,"fftopn"))
     @eval begin
         function ($a)(filename::AbstractString, mode::Integer=0)
-            ptr = Ref{Ptr{Void}}()
+            ptr = Ref{Ptr{Cvoid}}()
             status = Ref{Cint}(0)
             ccall(($b,libcfitsio), Cint,
-                  (Ref{Ptr{Void}},Ptr{UInt8},Cint,Ref{Cint}),
+                  (Ref{Ptr{Cvoid}},Ptr{UInt8},Cint,Ref{Cint}),
                   ptr, filename, mode, status)
             fits_assert_ok(status[], filename)
             FITSFile(ptr[])
@@ -289,14 +294,14 @@ end
 function fits_open_memfile(data::Vector{UInt8}, mode::Integer=0, filename="")
     # Only reading is supported right now
     @assert mode == 0
-    ptr = Ref{Ptr{Void}}(C_NULL)
+    ptr = Ref{Ptr{Cvoid}}(C_NULL)
     status = Ref{Cint}(0)
     handle = FITSMemoryHandle(pointer(data),length(data))
-    dataptr = Ptr{Ptr{Void}}(pointer_from_objref(handle))
-    sizeptr = Ptr{Csize_t}(dataptr+sizeof(Ptr{Void}))
+    dataptr = Ptr{Ptr{Cvoid}}(pointer_from_objref(handle))
+    sizeptr = Ptr{Csize_t}(dataptr+sizeof(Ptr{Cvoid}))
     ccall(("ffomem",libcfitsio), Cint,
-      (Ptr{Ptr{Void}},Ptr{UInt8},Cint,Ptr{Ptr{UInt8}},
-       Ptr{Csize_t}, Csize_t, Ptr{Void}, Ptr{Cint}),
+      (Ptr{Ptr{Cvoid}},Ptr{UInt8},Cint,Ptr{Ptr{UInt8}},
+       Ptr{Csize_t}, Csize_t, Ptr{Cvoid}, Ptr{Cint}),
        ptr, filename, mode, dataptr, sizeptr, 2880, C_NULL, status)
     fits_assert_ok(status[])
     FITSFile(ptr[]), handle
@@ -327,7 +332,7 @@ for (a,b) in ((:fits_close_file, "ffclos"),
             if f.ptr != C_NULL
                 status = Ref{Cint}(0)
                 ccall(($b,libcfitsio), Cint,
-                      (Ptr{Void},Ref{Cint}),
+                      (Ptr{Cvoid},Ref{Cint}),
                       f.ptr, status)
                 fits_assert_ok(status[])
                 f.ptr = C_NULL
@@ -344,10 +349,10 @@ Base.close(f::FITSFile) = fits_close_file(f)
 Return the name of the file associated with object `f`.
 """
 function fits_file_name(f::FITSFile)
-    value = Vector{UInt8}(1025)
+    value = Vector{UInt8}(undef, 1025)
     status = Ref{Cint}(0)
     ccall((:ffflnm,libcfitsio), Cint,
-          (Ptr{Void},Ptr{UInt8},Ref{Cint}),
+          (Ptr{Cvoid},Ptr{UInt8},Ref{Cint}),
           f.ptr, value, status)
     fits_assert_ok(status[])
     unsafe_string(pointer(value))
@@ -356,7 +361,7 @@ end
 function fits_file_mode(f::FITSFile)
     result = Ref{Cint}(0)
     status = Ref{Cint}(0)
-    ccall(("ffflmd", libcfitsio), Cint, (Ptr{Void}, Ref{Cint}, Ref{Cint}),
+    ccall(("ffflmd", libcfitsio), Cint, (Ptr{Cvoid}, Ref{Cint}, Ref{Cint}),
           f.ptr, result, status)
     fits_assert_ok(status[])
     result[]
@@ -377,18 +382,18 @@ function fits_get_hdrspace(f::FITSFile)
     morekeys = Ref{Cint}(0)
     status = Ref{Cint}(0)
     ccall((:ffghsp,libcfitsio), Cint,
-        (Ptr{Void},Ref{Cint},Ref{Cint},Ref{Cint}),
+        (Ptr{Cvoid},Ref{Cint},Ref{Cint},Ref{Cint}),
         f.ptr, keysexist, morekeys, status)
     fits_assert_ok(status[])
     (keysexist[], morekeys[])
 end
 
 function fits_read_key_str(f::FITSFile, keyname::String)
-    value = Vector{UInt8}(71)
-    comment = Vector{UInt8}(71)
+    value = Vector{UInt8}(undef, 71)
+    comment = Vector{UInt8}(undef, 71)
     status = Ref{Cint}(0)
     ccall((:ffgkys, libcfitsio), Cint,
-          (Ptr{Void}, Ptr{UInt8}, Ptr{UInt8}, Ptr{UInt8}, Ref{Cint}),
+          (Ptr{Cvoid}, Ptr{UInt8}, Ptr{UInt8}, Ptr{UInt8}, Ref{Cint}),
           f.ptr, keyname, value, comment, status)
     fits_assert_ok(status[])
     unsafe_string(pointer(value)), unsafe_string(pointer(comment))
@@ -396,10 +401,10 @@ end
 
 function fits_read_key_lng(f::FITSFile, keyname::String)
     value = Ref{Clong}(0)
-    comment = Vector{UInt8}(71)
+    comment = Vector{UInt8}(undef, 71)
     status = Ref{Cint}(0)
     ccall((:ffgkyj, libcfitsio), Cint,
-          (Ptr{Void}, Ptr{UInt8}, Ref{Clong}, Ptr{UInt8}, Ref{Cint}),
+          (Ptr{Cvoid}, Ptr{UInt8}, Ref{Clong}, Ptr{UInt8}, Ref{Cint}),
           f.ptr, keyname, value, comment, status)
     fits_assert_ok(status[])
     value[], unsafe_string(pointer(comment))
@@ -407,11 +412,11 @@ end
 
 function fits_read_keys_lng(f::FITSFile, keyname::String,
                             nstart::Integer, nmax::Integer)
-    value = Vector{Clong}(nmax - nstart + 1)
+    value = Vector{Clong}(undef, nmax - nstart + 1)
     nfound = Ref{Cint}(0)
     status = Ref{Cint}(0)
     ccall((:ffgknj, libcfitsio), Cint,
-          (Ptr{Void}, Ptr{UInt8}, Cint, Cint, Ptr{Clong}, Ref{Cint}, Ref{Cint}),
+          (Ptr{Cvoid}, Ptr{UInt8}, Cint, Cint, Ptr{Clong}, Ref{Cint}, Ref{Cint}),
           f.ptr, keyname, nstart, nmax, value, nfound, status)
     fits_assert_ok(status[])
     value, nfound[]
@@ -423,11 +428,11 @@ end
 Return the specified keyword.
 """
 function fits_read_keyword(f::FITSFile, keyname::String)
-    value = Vector{UInt8}(71)
-    comment = Vector{UInt8}(71)
+    value = Vector{UInt8}(undef, 71)
+    comment = Vector{UInt8}(undef, 71)
     status = Ref{Cint}(0)
     ccall((:ffgkey,libcfitsio), Cint,
-        (Ptr{Void},Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Ref{Cint}),
+        (Ptr{Cvoid},Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Ref{Cint}),
         f.ptr, keyname, value, comment, status)
     fits_assert_ok(status[])
     unsafe_string(pointer(value)), unsafe_string(pointer(comment))
@@ -441,10 +446,10 @@ Return the nth header record in the CHU. The first keyword in the
 header is at `keynum = 1`.
 """
 function fits_read_record(f::FITSFile, keynum::Integer)
-    card = Vector{UInt8}(81)
+    card = Vector{UInt8}(undef, 81)
     status = Ref{Cint}(0)
     ccall((:ffgrec,libcfitsio), Cint,
-        (Ptr{Void},Cint,Ptr{UInt8},Ref{Cint}),
+        (Ptr{Cvoid},Cint,Ptr{UInt8},Ref{Cint}),
         f.ptr, keynum, card, status)
     fits_assert_ok(status[])
     unsafe_string(pointer(card))
@@ -457,12 +462,12 @@ end
 Return the nth header record in the CHU. The first keyword in the header is at `keynum = 1`.
 """
 function fits_read_keyn(f::FITSFile, keynum::Integer)
-    keyname = Vector{UInt8}(9)
-    value = Vector{UInt8}(71)
-    comment = Vector{UInt8}(71)
+    keyname = Vector{UInt8}(undef, 9)
+    value = Vector{UInt8}(undef, 71)
+    comment = Vector{UInt8}(undef, 71)
     status = Ref{Cint}(0)
     ccall((:ffgkyn,libcfitsio), Cint,
-        (Ptr{Void},Cint,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Ref{Cint}),
+        (Ptr{Cvoid},Cint,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Ref{Cint}),
         f.ptr, keynum, keyname, value, comment, status)
     fits_assert_ok(status[])
     (unsafe_string(pointer(keyname)), unsafe_string(pointer(value)),
@@ -482,7 +487,7 @@ function fits_write_key(f::FITSFile, keyname::String,
              isa(value,Bool) ? Cint[value] : reinterpret(UInt8, [value])
     status = Ref{Cint}(0)
     ccall((:ffpky,libcfitsio), Cint,
-        (Ptr{Void},Cint,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Ref{Cint}),
+        (Ptr{Cvoid},Cint,Ptr{UInt8},Ptr{UInt8},Ptr{UInt8},Ref{Cint}),
         f.ptr, cfitsio_typecode(typeof(value)), keyname,
         cvalue, comment, status)
     fits_assert_ok(status[])
@@ -490,14 +495,14 @@ end
 
 function fits_write_date(f::FITSFile)
     status = Ref{Cint}(0)
-    ccall((:ffpdat, libcfitsio), Cint, (Ptr{Void}, Ref{Cint}), f.ptr, status)
+    ccall((:ffpdat, libcfitsio), Cint, (Ptr{Cvoid}, Ref{Cint}), f.ptr, status)
     fits_assert_ok(status[])
 end
 
 function fits_write_comment(f::FITSFile, comment::String)
     fits_assert_isascii(comment)
     status = Ref{Cint}(0)
-    ccall((:ffpcom, libcfitsio), Cint, (Ptr{Void}, Ptr{UInt8}, Ref{Cint}),
+    ccall((:ffpcom, libcfitsio), Cint, (Ptr{Cvoid}, Ptr{UInt8}, Ref{Cint}),
           f.ptr, comment, status)
     fits_assert_ok(status[])
 end
@@ -505,7 +510,7 @@ end
 function fits_write_history(f::FITSFile, history::String)
     fits_assert_isascii(history)
     status = Ref{Cint}(0)
-    ccall((:ffphis, libcfitsio), Cint, (Ptr{Void}, Ptr{UInt8}, Ref{Cint}),
+    ccall((:ffphis, libcfitsio), Cint, (Ptr{Cvoid}, Ptr{UInt8}, Ref{Cint}),
           f.ptr, history, status)
     fits_assert_ok(status[])
 end
@@ -516,12 +521,12 @@ for (a,T,S) in (("ffukys", :String, :(Ptr{UInt8})),
                 ("ffukyj", :Integer,     :Int64))
     @eval begin
         function fits_update_key(f::FITSFile, key::String, value::$T,
-                                 comment::Union{String, Ptr{Void}}=C_NULL)
+                                 comment::Union{String, Ptr{Cvoid}}=C_NULL)
             isa(value, String) && fits_assert_isascii(value)
             isa(comment, String) && fits_assert_isascii(comment)
             status = Ref{Cint}(0)
             ccall(($a, libcfitsio), Cint,
-                  (Ptr{Void}, Ptr{UInt8}, $S, Ptr{UInt8}, Ref{Cint}),
+                  (Ptr{Cvoid}, Ptr{UInt8}, $S, Ptr{UInt8}, Ref{Cint}),
                   f.ptr, key, value, comment, status)
             fits_assert_ok(status[])
         end
@@ -529,21 +534,21 @@ for (a,T,S) in (("ffukys", :String, :(Ptr{UInt8})),
 end
 
 function fits_update_key(f::FITSFile, key::String, value::AbstractFloat,
-                         comment::Union{String, Ptr{Void}}=C_NULL)
+                         comment::Union{String, Ptr{Cvoid}}=C_NULL)
     isa(comment, String) && fits_assert_isascii(comment)
     status = Ref{Cint}(0)
     ccall(("ffukyd", libcfitsio), Cint,
-          (Ptr{Void}, Ptr{UInt8}, Cdouble, Cint, Ptr{UInt8}, Ref{Cint}),
+          (Ptr{Cvoid}, Ptr{UInt8}, Cdouble, Cint, Ptr{UInt8}, Ref{Cint}),
           f.ptr, key, value, -15, comment, status)
     fits_assert_ok(status[])
 end
 
-function fits_update_key(f::FITSFile, key::String, value::Void,
-                         comment::Union{String, Ptr{Void}}=C_NULL)
+function fits_update_key(f::FITSFile, key::String, value::Cvoid,
+                         comment::Union{String, Ptr{Cvoid}}=C_NULL)
     isa(comment, String) && fits_assert_isascii(comment)
     status = Ref{Cint}(0)
     ccall(("ffukyu", libcfitsio), Cint,
-          (Ptr{Void}, Ptr{UInt8}, Ptr{UInt8}, Ref{Cint}),
+          (Ptr{Cvoid}, Ptr{UInt8}, Ptr{UInt8}, Ref{Cint}),
           f.ptr, key, comment, status)
     fits_assert_ok(status[])
 end
@@ -557,7 +562,7 @@ function fits_write_record(f::FITSFile, card::String)
     fits_assert_isascii(card)
     status = Ref{Cint}(0)
     ccall((:ffprec,libcfitsio), Cint,
-        (Ptr{Void},Ptr{UInt8},Ref{Cint}),
+        (Ptr{Cvoid},Ptr{UInt8},Ref{Cint}),
         f.ptr, card, status)
     fits_assert_ok(status[])
 end
@@ -570,7 +575,7 @@ Delete the keyword record at the specified index.
 function fits_delete_record(f::FITSFile, keynum::Integer)
     status = Ref{Cint}(0)
     ccall((:ffdrec,libcfitsio), Cint,
-        (Ptr{Void},Cint,Ref{Cint}),
+        (Ptr{Cvoid},Cint,Ref{Cint}),
         f.ptr, keynum, status)
     fits_assert_ok(status[])
 end
@@ -583,7 +588,7 @@ Delete the keyword named `keyname`.
 function fits_delete_key(f::FITSFile, keyname::String)
     status = Ref{Cint}(0)
     ccall((:ffdkey,libcfitsio), Cint,
-        (Ptr{Void},Ptr{UInt8},Ref{Cint}),
+        (Ptr{Cvoid},Ptr{UInt8},Ref{Cint}),
         f.ptr, keyname, status)
     fits_assert_ok(status[])
 end
@@ -599,9 +604,9 @@ function fits_hdr2str(f::FITSFile, nocomments::Bool=false)
     header = Ref{Ptr{UInt8}}()
     nkeys = Ref{Cint}(0)
     ccall((:ffhdr2str, libcfitsio), Cint,
-          (Ptr{Void}, Cint, Ptr{Ptr{UInt8}}, Cint,
+          (Ptr{Cvoid}, Cint, Ref{Ptr{UInt8}}, Cint,
            Ptr{Ptr{UInt8}}, Ref{Cint}, Ref{Cint}),
-          f.ptr, nocomments, &C_NULL, 0, header, nkeys, status)
+          f.ptr, nocomments, C_NULL, 0, header, nkeys, status)
     result = unsafe_string(header[])
 
     # free header pointer allocated by cfitsio (result is a copy)
@@ -654,7 +659,7 @@ for (a,b) in ((:fits_movabs_hdu,"ffmahd"),
             hdu_type = Ref{Cint}(0)
             status = Ref{Cint}(0)
             ccall(($b,libcfitsio), Cint,
-                  (Ptr{Void}, Cint, Ref{Cint}, Ref{Cint}),
+                  (Ptr{Cvoid}, Cint, Ref{Cint}, Ref{Cint}),
                   f.ptr, hduNum, hdu_type, status)
             fits_assert_ok(status[])
             hdu_int_to_type(hdu_type[])
@@ -679,7 +684,7 @@ function fits_movnam_hdu(f::FITSFile, extname::String, extver::Integer=0,
                          hdu_type::Integer=-1)
     status = Ref{Cint}(0)
     ccall((:ffmnhd,libcfitsio), Cint,
-          (Ptr{Void}, Cint, Ptr{UInt8}, Cint, Ref{Cint}),
+          (Ptr{Cvoid}, Cint, Ptr{UInt8}, Cint, Ref{Cint}),
           f.ptr, hdu_type, extname, extver, status)
     fits_assert_ok(status[])
 end
@@ -687,7 +692,7 @@ end
 function fits_get_hdu_num(f::FITSFile)
     hdunum = Ref{Cint}(0)
     ccall((:ffghdn,libcfitsio), Cint,
-          (Ptr{Void}, Ref{Cint}),
+          (Ptr{Cvoid}, Ref{Cint}),
           f.ptr, hdunum)
     hdunum[]
 end
@@ -696,7 +701,7 @@ function fits_get_hdu_type(f::FITSFile)
     hdutype = Ref{Cint}(0)
     status = Ref{Cint}(0)
     ccall((:ffghdt, libcfitsio), Cint,
-          (Ptr{Void}, Ref{Cint}, Ref{Cint}),
+          (Ptr{Cvoid}, Ref{Cint}, Ref{Cint}),
           f.ptr, hdutype, status)
     fits_assert_ok(status[])
     hdu_int_to_type(hdutype[])
@@ -717,7 +722,7 @@ for (a, b) in ((:fits_get_img_type,      "ffgidt"),
     @eval function ($a)(f::FITSFile)
         result = Ref{Cint}(0)
         status = Ref{Cint}(0)
-        ccall(($b, libcfitsio), Cint, (Ptr{Void}, Ref{Cint}, Ref{Cint}),
+        ccall(($b, libcfitsio), Cint, (Ptr{Cvoid}, Ref{Cint}, Ref{Cint}),
               f.ptr, result, status)
         fits_assert_ok(status[])
         result[]
@@ -729,13 +734,13 @@ end
 
 Create a new primary array or IMAGE extension with a specified data type and size.
 """
-function fits_create_img{T, S<:Integer}(f::FITSFile, ::Type{T},
-                                        naxes::Vector{S})
+function fits_create_img(f::FITSFile, ::Type{T},
+                         naxes::Vector{S}) where {T, S<:Integer}
     status = Ref{Cint}(0)
     ccall((:ffcrimll, libcfitsio), Cint,
-          (Ptr{Void}, Cint, Cint, Ptr{Int64}, Ref{Cint}),
+          (Ptr{Cvoid}, Cint, Cint, Ptr{Int64}, Ref{Cint}),
           f.ptr, bitpix_from_type(T), length(naxes),
-          Vector{Int64}(naxes), status)
+          Vector{Int64}(undef, naxes), status)
     fits_assert_ok(status[])
 end
 
@@ -744,12 +749,12 @@ end
 
 Write pixels from `data` into the FITS file.
 """
-function fits_write_pix{S<:Integer,T}(f::FITSFile, fpixel::Vector{S},
-                                      nelements::Integer, data::Array{T})
+function fits_write_pix(f::FITSFile, fpixel::Vector{S}, nelements::Integer,
+                        data::Array{T}) where {S<:Integer,T}
     status = Ref{Cint}(0)
     ccall((:ffppxll, libcfitsio), Cint,
-          (Ptr{Void}, Cint, Ptr{Int64}, Int64, Ptr{Void}, Ref{Cint}),
-          f.ptr, cfitsio_typecode(T), Vector{Int64}(fpixel),
+          (Ptr{Cvoid}, Cint, Ptr{Int64}, Int64, Ptr{Cvoid}, Ref{Cint}),
+          f.ptr, cfitsio_typecode(T), Vector{Int64}(undef, fpixel),
           nelements, data, status)
     fits_assert_ok(status[])
 end
@@ -758,16 +763,15 @@ function fits_write_pix(f::FITSFile, data::Array)
     fits_write_pix(f, ones(Int64, length(size(data))), length(data), data)
 end
 
-function fits_read_pix{S<:Integer,T}(f::FITSFile, fpixel::Vector{S},
-                                     nelements::Int, nullval::T,
-                                     data::Array{T})
+function fits_read_pix(f::FITSFile, fpixel::Vector{S},  nelements::Int,
+                       nullval::T, data::Array{T}) where {S<:Integer,T}
     anynull = Ref{Cint}(0)
     status = Ref{Cint}(0)
     ccall((:ffgpxvll, libcfitsio), Cint,
-          (Ptr{Void}, Cint, Ptr{Int64}, Int64, Ptr{Void}, Ptr{Void},
+          (Ptr{Cvoid}, Cint, Ptr{Int64}, Int64, Ref{T}, Ptr{T},
            Ref{Cint}, Ref{Cint}),
-          f.ptr, cfitsio_typecode(T), Vector{Int64}(fpixel),
-          nelements, &nullval, data, anynull, status)
+          f.ptr, cfitsio_typecode(T), Vector{Int64}(undef, fpixel),
+          nelements, nullval, data, anynull, status)
     fits_assert_ok(status[])
     anynull[]
 end
@@ -777,14 +781,14 @@ end
 
 Read pixels from the FITS file into `data`.
 """
-function fits_read_pix{S<:Integer,T}(f::FITSFile, fpixel::Vector{S},
-                                     nelements::Int, data::Array{T})
+function fits_read_pix(f::FITSFile, fpixel::Vector{S},
+                       nelements::Int, data::Array{T}) where {S<:Integer,T}
     anynull = Ref{Cint}(0)
     status = Ref{Cint}(0)
     ccall((:ffgpxvll, libcfitsio), Cint,
-          (Ptr{Void}, Cint, Ptr{Int64}, Int64, Ptr{Void}, Ptr{Void},
+          (Ptr{Cvoid}, Cint, Ptr{Int64}, Int64, Ptr{Cvoid}, Ptr{Cvoid},
            Ref{Cint}, Ref{Cint}),
-          f.ptr, cfitsio_typecode(T), Vector{Int64}(fpixel),
+          f.ptr, cfitsio_typecode(T), Vector{Int64}(undef, fpixel),
           nelements, C_NULL, data, anynull, status)
     fits_assert_ok(status[])
     anynull[]
@@ -794,18 +798,19 @@ function fits_read_pix(f::FITSFile, data::Array)
     fits_read_pix(f, ones(Int64,length(size(data))), length(data), data)
 end
 
-function fits_read_subset{S1<:Integer,S2<:Integer,S3<:Integer,T}(
-             f::FITSFile, fpixel::Vector{S1}, lpixel::Vector{S2},
-             inc::Vector{S3}, data::Array{T})
+function fits_read_subset(f::FITSFile, fpixel::Vector{S1}, lpixel::Vector{S2},
+                          inc::Vector{S3},
+                          data::Array{T}) where {S1<:Integer,S2<:Integer,
+                                                 S3<:Integer,T}
     anynull = Ref{Cint}(0)
     status = Ref{Cint}(0)
     ccall((:ffgsv, libcfitsio), Cint,
-          (Ptr{Void}, Cint, Ptr{Clong}, Ptr{Clong}, Ptr{Clong}, Ptr{Void},
-           Ptr{Void}, Ref{Cint}, Ref{Cint}),
+          (Ptr{Cvoid}, Cint, Ptr{Clong}, Ptr{Clong}, Ptr{Clong}, Ptr{Cvoid},
+           Ptr{Cvoid}, Ref{Cint}, Ref{Cint}),
           f.ptr, cfitsio_typecode(T),
-          Vector{Clong}(fpixel),
-          Vector{Clong}(lpixel),
-          Vector{Clong}(inc),
+          Vector{Clong}(undef, fpixel),
+          Vector{Clong}(undef, lpixel),
+          Vector{Clong}(undef, inc),
           C_NULL, data, anynull, status)
     fits_assert_ok(status[])
     anynull[]
@@ -815,7 +820,7 @@ function fits_copy_image_section(fin::FITSFile, fout::FITSFile,
                                  section::String)
     status = Ref{Cint}(0)
     ccall((:fits_copy_image_section,libcfitsio), Cint,
-          (Ptr{Void}, Ptr{Void}, Ptr{UInt8}, Ref{Cint}),
+          (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{UInt8}, Ref{Cint}),
           fin.ptr, fout.ptr, section, status)
     fits_assert_ok(status[])
 end
@@ -896,7 +901,7 @@ for (a,b) in ((:fits_create_binary_tbl, 2),
             status = Ref{Cint}(0)
 
             ccall(("ffcrtb", libcfitsio), Cint,
-                  (Ptr{Void}, Cint, Int64, Cint,
+                  (Ptr{Cvoid}, Cint, Int64, Cint,
                    Ptr{Ptr{UInt8}}, Ptr{Ptr{UInt8}},
                    Ptr{Ptr{UInt8}}, Ptr{UInt8}, Ref{Cint}),
                   f.ptr, $b, numrows, ntype,
@@ -921,7 +926,7 @@ for (a,b,T) in ((:fits_get_num_cols,  "ffgncl",  :Cint),
             result = Ref{$T}(0)
             status = Ref{Cint}(0)
             ccall(($b,libcfitsio), Cint,
-                  (Ptr{Void}, Ref{$T}, Ref{Cint}),
+                  (Ptr{Cvoid}, Ref{$T}, Ref{Cint}),
                   f.ptr, result, status)
             fits_assert_ok(status[])
             result[]
@@ -936,7 +941,7 @@ function fits_get_colnum(f::FITSFile, tmplt::String; case_sensitive::Bool=true)
     # Second argument is case-sensitivity of search: 0 = case-insensitive
     #                                                1 = case-sensitive
     ccall(("ffgcno", libcfitsio), Cint,
-          (Ptr{Void}, Cint, Ptr{UInt8}, Ref{Cint}, Ref{Cint}),
+          (Ptr{Cvoid}, Cint, Ptr{UInt8}, Ref{Cint}, Ref{Cint}),
           f.ptr, case_sensitive, tmplt, result, status)
     fits_assert_ok(status[])
     return result[]
@@ -986,7 +991,7 @@ function fits_get_coltype end
         width = Ref{$T}(0)
         status = Ref{Cint}(0)
         ccall(($ffgtcl,libcfitsio), Cint,
-              (Ptr{Void}, Cint, Ref{Cint}, Ref{$T}, Ref{$T}, Ref{Cint}),
+              (Ptr{Cvoid}, Cint, Ref{Cint}, Ref{$T}, Ref{$T}, Ref{Cint}),
               ff.ptr, colnum, typecode, repcnt, width, status)
         fits_assert_ok(status[])
         return Int(typecode[]), Int(repcnt[]), Int(width[])
@@ -998,7 +1003,7 @@ function fits_get_coltype end
         width = Ref{$T}(0)
         status = Ref{Cint}(0)
         ccall(($ffeqty,libcfitsio), Cint,
-              (Ptr{Void}, Cint, Ref{Cint}, Ref{$T}, Ref{$T}, Ref{Cint}),
+              (Ptr{Cvoid}, Cint, Ref{Cint}, Ref{$T}, Ref{$T}, Ref{Cint}),
               ff.ptr, colnum, typecode, repcnt, width, status)
         fits_assert_ok(status[])
         return Int(typecode[]), Int(repcnt[]), Int(width[])
@@ -1006,10 +1011,10 @@ function fits_get_coltype end
 
     function fits_get_img_size(f::FITSFile)
         ndim = fits_get_img_dim(f)
-        naxes = Vector{$T}(ndim)
+        naxes = Vector{$T}(undef, ndim)
         status = Ref{Cint}(0)
         ccall(($ffgisz, libcfitsio), Cint,
-              (Ptr{Void}, Cint, Ptr{$T}, Ref{Cint}),
+              (Ptr{Cvoid}, Cint, Ptr{$T}, Ref{Cint}),
               f.ptr, ndim, naxes, status)
         fits_assert_ok(status[])
         naxes
@@ -1019,7 +1024,7 @@ function fits_get_coltype end
         result = Ref{$T}(0)
         status = Ref{Cint}(0)
         ccall(($ffgnrw, libcfitsio), Cint,
-              (Ptr{Void}, Ref{$T}, Ref{Cint}),
+              (Ptr{Cvoid}, Ref{$T}, Ref{Cint}),
               f.ptr, result, status)
         fits_assert_ok(status[])
         return Int(result[])
@@ -1031,11 +1036,11 @@ function fits_get_coltype end
     # returns `[r]` with `r` equals to the repeat count in the TFORM
     # keyword.
     function fits_read_tdim(ff::FITSFile, colnum::Integer)
-        naxes = Vector{$T}(99)  # 99 is the maximum allowed number of axes
+        naxes = Vector{$T}(undef, 99)  # 99 is the maximum allowed number of axes
         naxis = Ref{Cint}(0)
         status = Ref{Cint}(0)
         ccall(($ffgtdm,libcfitsio), Cint,
-              (Ptr{Void}, Cint, Cint, Ref{Cint}, Ptr{$T}, Ref{Cint}),
+              (Ptr{Cvoid}, Cint, Cint, Ref{Cint}, Ptr{$T}, Ref{Cint}),
               ff.ptr, colnum, length(naxes), naxis, naxes, status)
         fits_assert_ok(status[])
         return naxes[1:naxis[]]
@@ -1045,7 +1050,7 @@ function fits_get_coltype end
                                  naxes::Array{$T})
         status = Ref{Cint}(0)
         ccall(($ffptdm, libcfitsio), Cint,
-              (Ptr{Void}, Cint, Cint, Ptr{$T}, Ref{Cint}),
+              (Ptr{Cvoid}, Cint, Cint, Ptr{$T}, Ref{Cint}),
               ff.ptr, colnum, length(naxes), naxes, status)
         fits_assert_ok(status[])
     end
@@ -1055,7 +1060,7 @@ function fits_get_coltype end
         offset = Ref{$T}(0)
         status = Ref{Cint}(0)
         ccall(($ffgdes, libcfitsio), Cint,
-              (Ptr{Void}, Cint, Int64, Ref{$T}, Ref{$T}, Ref{Cint}),
+              (Ptr{Cvoid}, Cint, Int64, Ref{$T}, Ref{$T}, Ref{Cint}),
               f.ptr, colnum, rownum, repeat, offset, status)
         fits_assert_ok(status[])
         return Int(repeat[]), Int(offset[])
@@ -1094,13 +1099,13 @@ function fits_read_col(f::FITSFile,
     abs(typecode) == 16 || error("not a string column")
 
     # create an array of character buffers of the correct width
-    buffers = [Vector{UInt8}(width) for i in 1:length(data)]
+    buffers = [Vector{UInt8}(undef, width) for i in 1:length(data)]
 
     # Call the CFITSIO function
     anynull = Ref{Cint}(0)
     status = Ref{Cint}(0)
     ccall((:ffgcvs, libcfitsio), Cint,
-          (Ptr{Void}, Cint, Int64, Int64, Int64,
+          (Ptr{Cvoid}, Cint, Int64, Int64, Int64,
            Ptr{UInt8}, Ptr{Ptr{UInt8}}, Ref{Cint}, Ref{Cint}),
           f.ptr, colnum, firstrow, firstelem, length(data),
           " ", buffers, anynull, status)
@@ -1115,16 +1120,16 @@ function fits_read_col(f::FITSFile,
     end
 end
 
-function fits_read_col{T}(f::FITSFile,
-                          colnum::Integer,
-                          firstrow::Integer,
-                          firstelem::Integer,
-                          data::Array{T})
+function fits_read_col(f::FITSFile,
+                       colnum::Integer,
+                       firstrow::Integer,
+                       firstelem::Integer,
+                       data::Array{T}) where {T}
     anynull = Ref{Cint}(0)
     status = Ref{Cint}(0)
     ccall((:ffgcv,libcfitsio), Cint,
-          (Ptr{Void}, Cint, Cint, Int64, Int64, Int64,
-           Ptr{Void}, Ptr{Void}, Ref{Cint}, Ref{Cint}),
+          (Ptr{Cvoid}, Cint, Cint, Int64, Int64, Int64,
+           Ptr{Cvoid}, Ptr{Cvoid}, Ref{Cint}, Ref{Cint}),
           f.ptr, cfitsio_typecode(T), colnum,
           firstrow, firstelem, length(data),
           C_NULL, data, anynull, status)
@@ -1155,22 +1160,22 @@ function fits_write_col(f::FITSFile,
     for el in data; fits_assert_isascii(el); end
     status = Ref{Cint}(0)
     ccall((:ffpcls, libcfitsio), Cint,
-          (Ptr{Void}, Cint, Int64, Int64, Int64,
+          (Ptr{Cvoid}, Cint, Int64, Int64, Int64,
            Ptr{Ptr{UInt8}}, Ref{Cint}),
           f.ptr, colnum, firstrow, firstelem, length(data),
           data, status)
     fits_assert_ok(status[])
 end
 
-function fits_write_col{T}(f::FITSFile,
-                           colnum::Integer,
-                           firstrow::Integer,
-                           firstelem::Integer,
-                           data::Array{T})
+function fits_write_col(f::FITSFile,
+                        colnum::Integer,
+                        firstrow::Integer,
+                        firstelem::Integer,
+                        data::Array{T}) where {T}
     status = Ref{Cint}(0)
     ccall((:ffpcl, libcfitsio), Cint,
-          (Ptr{Void}, Cint, Cint, Int64, Int64, Int64,
-           Ptr{Void}, Ref{Cint}),
+          (Ptr{Cvoid}, Cint, Cint, Int64, Int64, Int64,
+           Ptr{Cvoid}, Ref{Cint}),
           f.ptr, cfitsio_typecode(T), colnum,
           firstrow, firstelem, length(data),
           data, status)
@@ -1204,7 +1209,7 @@ for (a,b) in ((:fits_insert_rows, "ffirow"),
         function ($a)(f::FITSFile, firstrow::Integer, nrows::Integer)
             status = Ref{Cint}(0)
             ccall(($b,libcfitsio), Cint,
-                  (Ptr{Void}, Int64, Int64, Ref{Cint}),
+                  (Ptr{Cvoid}, Int64, Int64, Ref{Cint}),
                   f.ptr, firstrow, nrows, status)
             fits_assert_ok(status[])
         end

--- a/src/table.jl
+++ b/src/table.jl
@@ -82,10 +82,11 @@ end
 # Parse max length from tform for a variable column
 function var_col_maxlen(tform::String)
     maxlen = -1
-    i = search(tform, '(')
+    i = something(findfirst(isequal('('), tform), 0)
     if i > 0
-        j = search(tform, ')', i)
-        if j > 0
+        j = something(findnext(isequal(')'), tform, i), 0)
+        if j > i
+            # FIXME: use `tryparse`
             try maxlen = parseint(tform[i+1:j-1]) catch end
         end
     end
@@ -441,7 +442,7 @@ function fits_read_var_col(f::FITSFile, colnum::Integer, data::Vector{String})
         fits_assert_ok(status[])
 
         # Create string out of the buffer, terminating at null characters
-        zeropos = search(buffer, 0x00)
+        zeropos = something(findfirst(isequal(0x00), buffer), 0)
         data[i] = (zeropos >= 1) ? String(buffer[1:(zeropos-1)]) :
                                    String(buffer)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using FITSIO
-using Base.Test
+using Compat
+using Compat.Test
 
 @testset "Images" begin
     # Create a FITS instance and loop over supported types.
@@ -76,7 +77,7 @@ end
     ## Binary table
     indata = Dict{String, Array}()
     for (i, T) in enumerate([UInt8, Int8, UInt16, Int16, UInt32, Int32, Int64,
-                             Float32, Float64, Complex64, Complex128])
+                             Float32, Float64, ComplexF32, ComplexF64])
         indata["col$i"] = T[1:20;]
     end
     i = length(indata) + 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,16 @@
 using FITSIO
+
+# Dela with compatibility issues.
 using Compat
 using Compat.Test
+using Compat.Random
 
 @testset "Images" begin
     # Create a FITS instance and loop over supported types.
     fname = tempname() * ".fits"
     FITS(fname, "w") do f
-        for T in [UInt8, Int8, UInt16, Int16, UInt32, Int32, Int64,
-                  Float32, Float64]
+        for T in (UInt8, Int8, UInt16, Int16, UInt32, Int32, Int64,
+                  Float32, Float64)
             indata = reshape(T[1:100;], 5, 20)
 
             # Test writing the data to a new extension


### PR DESCRIPTION
This PR is about an update of FITSIO.jl so that it can be used with Julia 0.6, 0.7 and 1.0.

I have checked that all tests pass successfully with Julia versions 0.6.4, 0.7.0 and 1.0.0 with the following code:

```julia
using Pkg # of course, not for Julia 0.6
Pkg.clone("https://github.com/emmt/FITSIO.jl.git")
Pkg.build("FITSIO")
Pkg.test("FITSIO")
```
There are many changes, which explain that the PR is split in several commits. Hopefully these changes do not affect the API at the user level (as a proof: appart from `using Compat`, the file `test/runtests.jl` is almost unchanged).

Due to the deprecation of `Nullable{T}`, I had to make a choice for the internal API of a few methods used to parse FITS header values. The Julia recommendation is to replace `Nullable{T}` by `Union{Some{T},Nothing}` to distinguish whether the return value is a true `Nothing` or is missing.  This however leads to a somewhat overcomplex code, it seemed more simple to follow the behavior of `tryparse(T,s)` which (as of Julia version ≥ 0.7) yields either a value of type `T` or `nothing`.  Thus the following behavior is currently implemented:

* The methods `try_parse_hdrval(T,s)` behave as `tryparse(T,s)`.

* The method `try_parse_hdrval(s)` returns a value of type `String`,  `Bool`, `Int`, `Float64` or `Nothing`.  The latter occurs if the value string `s` is empty or invalid.

* The method `parse_header_val(s)` returns a value of type `String`, `Bool`, `Int`, `Float64` or `Nothing`.  The former occurs (a `String`) occurs if the value string `s` is a FITS string or if it is invalid.  The latter occurs if the value string `s` is empty.

This works but this choice is not completely satisfying because the result of `parse_header_val(s)` is ambiguous.  I would rather have method `parse_header_val(s)` return a value of type `String`, `Bool`, `Int`, `Float64` or `Nothing` (if value is empty) and throw an error if value cannot be parsed and remove method `try_parse_hdrval(s)` (with a single argument).  Throwing an error is necessary because there is no other means to realize that someting wrong occured. These methods are *private* (in the sense that they are not in the [official documentation](http://juliaastro.github.io/FITSIO.jl/latest/)) so that this choice should not affect end users.  More generally, we should have a discussion about how to report errors when reading a FITS keyword because there are 2 cases of failure: either the keyword is not found or its value cannot be parsed.  Throwing distinct exceptions for these cases could solve the issue.

I foresee to make a further PR along these lines.  Otherwise, I suggest to make a new official release (perhaps after a short period of testing) because many users (especially the new ones) will use Julia 1.0 now it has been released.
