### PR TITLE
Issue deprecation warning for read(::TableHDU, ::String) with no keyword

### DIFF
--- a/src/table.jl
+++ b/src/table.jl
@@ -454,7 +454,26 @@ function read(hdu::ASCIITableHDU, colname::String; case_sensitive::Bool=true)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
 
     nrows = fits_get_num_rows(hdu.fitsfile)
-    colnum = fits_get_colnum(hdu.fitsfile, colname, case_sensitive=case_sensitive)
+    ### TODO: the following `if` is a deprecation warning for the case-sensitivity change.
+    ### Remove it when we want to remove the deprecation.
+    # `case_sensitive=true` is the default behavior, the only case where the deprecation is
+    # necessary.
+    if case_sensitive
+        colnum = try
+            fits_get_colnum(hdu.fitsfile, colname, case_sensitive=true)
+        catch
+            # This temporary variable is to allow showing the depwarn only if the function
+            # didn't error.
+            tmp = fits_get_colnum(hdu.fitsfile, colname, case_sensitive=false)
+            Base.depwarn("The new default behavior of `read(::ASCIITableHDU, ::String)`\n" *
+                         "is to require case-sensitive column names.  Either pass the column name\n"*
+                         "with proper capitalization or use `read(hdu, \"$(colname)\", case_sensitive=false)`",
+                         :read)
+            tmp
+        end
+    else
+        colnum = fits_get_colnum(hdu.fitsfile, colname, case_sensitive=case_sensitive)
+    end
 
     typecode, repcnt, width = fits_get_eqcoltype(hdu.fitsfile, colnum)
     T = CFITSIO_COLTYPE[typecode]
@@ -485,7 +504,27 @@ function read(hdu::TableHDU, colname::String; case_sensitive::Bool=true)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
 
     nrows = fits_get_num_rows(hdu.fitsfile)
-    colnum = fits_get_colnum(hdu.fitsfile, colname, case_sensitive=case_sensitive)
+    ### TODO: the following `if` is a deprecation warning for the case-sensitivity change.
+    ### Remove it when we want to remove the deprecation.
+    # `case_sensitive=true` is the default behavior, the only case where the deprecation is
+    # necessary.
+    if case_sensitive
+        colnum = try
+            fits_get_colnum(hdu.fitsfile, colname, case_sensitive=true)
+        catch
+            # This temporary variable is to allow showing the depwarn only if the function
+            # didn't error.
+            tmp = fits_get_colnum(hdu.fitsfile, colname, case_sensitive=false)
+            Base.depwarn("The new default behavior of `read(::TableHDU, ::String)`\n" *
+                         "is to require case-sensitive column names.  Either pass the column name\n"*
+                         "with proper capitalization or use `read(hdu, \"$(colname)\", case_sensitive=false)`",
+                         :read)
+            tmp
+        end
+    else
+        colnum = fits_get_colnum(hdu.fitsfile, colname, case_sensitive=case_sensitive)
+    end
+    
 
     T, rowsize, isvariable = fits_get_col_info(hdu.fitsfile, colnum)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,7 +106,13 @@ end
         @test colname in colnames
     end
 
-    @test_throws ErrorException read(f[2], "vcol", case_sensitive=false)
+    # TODO: remove the tests for deprecation warnings when we don't issue them, but keep the
+    # `@test_throws` test.
+    @test_throws ErrorException @test_nowarn(read(f[2], "vcol", case_sensitive=false))
+    @test_nowarn read(f[2], "col2")
+    @static if VERSION >= v"0.7"
+        @test_logs (:warn, r"case_sensitive") read(f[2], "COL2")
+    end
 
     # Test representation
     @test repr(f[2])[end-38:end] == "\n\n         (*) = variable-length column"


### PR DESCRIPTION
Use a `try`-`catch` block to issue the warnings.  Ref. #98.

This is done only for `read` because it's the user-visible function.  I don't see how we can issue the warning only once if it's also inside `fits_get_colnum`.

I'd also like to add a couple of tests to make sure that the warning is emitted in the correct case, but I can't make `@test_warn` and `@test_nowarn` work.  If anyone has a clue about how to do this, please share!