### PR TITLE
Make ImageHDU parametric

### DIFF
--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -46,7 +46,7 @@ import .Libcfitsio: libcfitsio,
 # HDU Types
 abstract type HDU end
 
-mutable struct ImageHDU <: HDU
+mutable struct ImageHDU{T,N} <: HDU
     fitsfile::FITSFile
     ext::Int
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,8 @@ using Random # for `randstring`
             write(f, indata)
 
             # test reading the full array
-            outdata = read(f[end])
+            @test f[end] isa ImageHDU{T,length(size(indata))}
+            outdata = @inferred read(f[end])
             @test indata == outdata
             @test eltype(indata) == eltype(outdata)
 


### PR DESCRIPTION
The parameters are the same as the data it represents: the type of the elements and the number of dimensions of the array.  As a result, `read(::ImageHDU)` is type-stable.

Ref #119.