### PR TITLE
read and write StridedArrays as images

### DIFF
--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -43,9 +43,7 @@ using .Libcfitsio
 import .Libcfitsio: libcfitsio,
                     fits_assert_ok,
                     fits_assert_isascii,
-                    TYPE_FROM_BITPIX,
-                    ContiguousAbstractArray
-
+                    TYPE_FROM_BITPIX
 
 # HDU Types
 abstract type HDU end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,8 +80,12 @@ using Random # for `randstring`
                 indata = reshape(Float32[1:400;], 20, 20)
                 write(f, indata)
 
+                indata3D = reshape([1:30;], 3, 2, 5)
+                write(f, indata3D)
+
                 # Read the entire array using read to compare with read!
                 a = read(f[1])
+                a3D = read(f[2])
 
                 # Read the entire array
                 b = zeros(eltype(indata),size(indata))
@@ -133,23 +137,83 @@ using Random # for `randstring`
                 b = zeros(eltype(indata),1)
                 @test_throws DimensionMismatch read!(f[1],b,1,1)
 
+                b3D = zeros(eltype(indata3D),size(indata3D))
+                read!(f[2],b3D)
+                @test a3D == b3D
+                read!(f[2],b3D,:,:,:)
+                @test a3D == b3D
+
+                b0D = zeros(eltype(indata))
+                read!(f[1],b0D,1,1)
+                @test a[1,1] == b0D[]
+
                 @testset "read into views" begin
+
                     b = zeros(eltype(indata),size(indata))
 
                     # Entire array
-                    b_view = view(b,:,:)
+                    b_view = @view b[:,:]
                     read!(f[1],b_view)
                     @test a == b
+                    
+                    b_view = @view b3D[:,:,:]
+                    read!(f[2],b_view)
+                    @test a3D == b3D
 
-                    for ax2 in axes(b,2)
-                        b_view = view(b,:,ax2)
-                        read!(f[1],b_view,:,ax2)
-                        @test a[:,ax2] == b[:,ax2]
+                    @testset "1D slices of a 2D array" begin
+                        for ax2 in axes(b,2)
+                            b .= zero(eltype(b))
+                            b_view = @view b[:,ax2]
+                            read!(f[1],b_view,:,ax2)
+                            @test a[:,ax2] == b[:,ax2]
+                        end
+
+                        # Non-contiguous views can not be read into
+                        b .= zero(eltype(b))
+                        b_view = @view b[1,:]
+                        @test_throws ArgumentError read!(f[1],b_view,1,:)    
                     end
 
-                    # Non-contiguous views can not be read into
-                    b_view = view(b,1,:)
-                    @test_throws MethodError read!(f[1],b_view,1,:)
+                    @testset "1D slices of a 3D array" begin
+                        for ax2 in axes(b3D,2), ax3 in axes(b3D,3)
+                            b3D .= zero(eltype(b3D))
+                            b_view = @view b3D[:,ax2,ax3]
+                            read!(f[2],b_view,:,ax2,ax3)
+                            @test a3D[:,ax2,ax3] == b3D[:,ax2,ax3]
+                        end
+
+                        # Non-contiguous views can not be read into
+                        b3D .= zero(eltype(b3D))
+                        b_view = @view b3D[1,1,:]
+                        @test_throws ArgumentError read!(f[2],b_view,1,1,:)
+
+                        b_view = @view b3D[1,:,1]
+                        @test_throws ArgumentError read!(f[2],b_view,1,:,1)
+                    end
+
+                    @testset "2D slices of a 3D array" begin
+                        for ax3 in axes(b3D,3)
+                            b3D .= zero(eltype(b3D))
+                            b_view = @view b3D[:,:,ax3]
+                            read!(f[2],b_view,:,:,ax3)
+                            @test a3D[:,:,ax3] == b3D[:,:,ax3]
+                        end
+
+                        # Non-contiguous views can not be read into
+                        b3D .= zero(eltype(b3D))
+                        b_view = @view b3D[:,1,:]
+                        @test_throws ArgumentError read!(f[2],b_view,:,1,:)
+
+                        b_view = @view b3D[1,:,:]
+                        @test_throws ArgumentError read!(f[2],b_view,1,:,:)
+                    end
+
+                    @testset "0D view" begin
+                        b .= zero(eltype(b))
+                        b_view = @view b[1,1]
+                        read!(f[1],b_view,1,1)
+                        @test a[1,1] == b[1,1]
+                    end
                 end
             end
         finally
@@ -235,80 +299,59 @@ using Random # for `randstring`
         end
     end
 
-    @testset "reinterpreted complex" begin
-        @testset "read" begin
-            fname = tempname() * ".fits"
+    @testset "write views to file" begin
+        fname = tempname() * ".fits"
+        b = reshape([1:8;],2,2,2)
 
-            function _testreadcomplex(arr::AbstractArray{Complex{T}}) where T
-                FITS(fname,"w") do f
-                    write(f, collect(reinterpret(T,arr)) )
-                end
-                b = similar(arr)
-                FITS(fname,"r") do f
-                    read!(f[1], reinterpret(T,b))
-                end
-                @test b == arr
-                c = FITS(fname,"r") do f
-                    read(f[1])
-                end
-                @test c == reinterpret(T,arr)
-            end
-
-            function testreadcomplex(arr::Array{Complex{T}}) where T
-                # Given a complex array, reinterpret it as float and write to file
-                # Read it back and compare
-                _testreadcomplex(arr)
-
-                # Write a contiguous subsection instead of the entire array
-                region = 1:size(arr,1)
-                arrv = @view arr[region]
-                _testreadcomplex(arrv)
-            end
-
+        @testset "2D slice of a 3D array" begin
             try
-                testreadcomplex(ones(ComplexF64,3))
-                testreadcomplex(ones(ComplexF64,3,4))
-                testreadcomplex(ones(ComplexF64,3,4,5))
+                FITS(fname,"r+") do f
+                    for (ind,ax3) in enumerate(axes(b,3))
+                        b_view = @view b[:,:,ax3]
+                        write(f,b_view)
+                        @test read(f[ind]) == b_view
+                    end
+                end
             finally
-                rm(fname,force=true)
+                rm(fname)
+            end
+        end
+            
+        @testset "1D slice of a 3D array" begin
+            try
+                FITS(fname,"r+") do f
+                    ax23iter = Iterators.product(axes(b)[2:3]...)
+                    for (ind,(ax2,ax3)) in enumerate(ax23iter)
+                        b_view = @view b[:,ax2,ax3]
+                        write(f,b_view)
+                        @test read(f[ind]) == b_view
+                    end
+                end
+            finally
+                rm(fname)
             end
         end
 
-        @testset "write" begin
-            fname = tempname() * ".fits"
-
-            function _testwritecomplex(arr::AbstractArray{Complex{T}}) where T
-                FITS(fname,"w") do f
-                    write(f, reinterpret(T,arr) )
-                end
-                a = FITS(fname,"r") do f
-                    read(f[1])
-                end
-                b = collect(reinterpret(T,arr))
-                @test b == a
-                c = FITS(fname,"r") do f
-                    reinterpret(Complex{T},read(f[1]))
-                end
-                @test c == arr
-            end
-
-            function testwritecomplex(arr::Array{Complex{T}}) where T
-                # Given a complex array, reinterpret it as float and write to file
-                # Read it back and compare
-                _testwritecomplex(arr)
-
-                # Write a subsection instead of the entire array
-                region = 1:size(arr,1)
-                arrv = @view arr[region]
-                _testwritecomplex(arrv)
-            end
-
+        @testset "Non-contiguous" begin
             try
-                testwritecomplex(ones(ComplexF64,3))
-                testwritecomplex(ones(ComplexF64,3,4))
-                testwritecomplex(ones(ComplexF64,3,4,5))
+                FITS(fname,"r+") do f
+                    b_view = @view b[:,1,:]
+                    @test_throws ArgumentError write(f,b_view)
+                    
+                    b_view = @view b[1,:,:]
+                    @test_throws ArgumentError write(f,b_view)
+
+                    b_view = @view b[1,1,:]
+                    @test_throws ArgumentError write(f,b_view)
+
+                    b_view = @view b[1,:,1]
+                    @test_throws ArgumentError write(f,b_view)
+
+                    # write something random to avoid the error on closing
+                    write(f,zeros(1))
+                end
             finally
-                rm(fname,force=true)
+                rm(fname)
             end
         end
     end


### PR DESCRIPTION
Following the discussion in #131 , this is an initial attempt to replace the messy unions of contiguous types by `StridedArray`s. The `cfitsio` library seems to require a contiguous memory layout for the arrays to be written and read into, however AFAIK there isn't an obvious contiguous `StridedArray` type to dispatch on. To get around this currently we carry out a runtime check to ensure that the strides along the various axes are compatible with a contiguous layout. For the most part this seems to work, however further tests might be warranted.

```julia
julia> fitsfile=tempname();

julia> b = reshape([1:8;],2,2,2);

julia> b_view = @view b[:,:,1]
2×2 view(::Array{Int64,3}, :, :, 1) with eltype Int64:
 1  3
 2  4

julia> FITS(fitsfile,"w") do f
       write(f, b_view)
       end

julia> FITS(fitsfile,"r") do f
       read(f[1])
       end
2×2 Array{Int64,2}:
 1  3
 2  4

# Non-contiguous views throw an error
julia> b_view = @view b[:,1,:]
2×2 view(::Array{Int64,3}, :, 1, :) with eltype Int64:
 1  5
 2  6

julia> FITS(fitsfile,"w") do f
       write(f, b_view)
       end
ArgumentError: data to be written out needs to be contiguously stored

# Complex arrays may be reinterpreted as float as in #131 
julia> FITS(fitsfile,"w") do f
       write(f,reinterpret(Float64,zeros(ComplexF64,1,2)))
       end

julia> FITS(fitsfile,"r") do f
       read(f[1])
       end
2×2 Array{Float64,2}:
 0.0  0.0
 0.0  0.0
```