### PR TITLE
Added method to get default header for `AbstractArray`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,8 +9,8 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 CFITSIO = "1"
-julia = "1.3"
 Reexport = "0.2"
+julia = "1.3"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -12,7 +12,7 @@ export FITS,
        get_comment,
        set_comment!,
        copy_section,
-       get_default_header
+       default_header
 
 import Base: getindex,
              setindex!,

--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -11,7 +11,8 @@ export FITS,
        read_header,
        get_comment,
        set_comment!,
-       copy_section
+       copy_section,
+       get_default_header
 
 import Base: getindex,
              setindex!,
@@ -33,7 +34,7 @@ using Printf
 import Base: iterate, lastindex
 # Libcfitsio submodule
 
-## Have to manually import while deprecating `libcfitsio_version`. 
+## Have to manually import while deprecating `libcfitsio_version`.
 ## After removing that, can return to using CFITSIO
 import CFITSIO: FITSFile,
                 FITSMemoryHandle,

--- a/src/header.jl
+++ b/src/header.jl
@@ -424,11 +424,11 @@ function show(io::IO, hdr::FITSHeader)
 end
 
 """
-    get_default_header(data::AbstractArray)
+    default_header(data::AbstractArray)
 
 Creates a default header for the given array with the `SIMPLE`, `BITPIX`, `NAXIS`, `NAXIS*`, and `EXTEND` entries.
 """
-function get_default_header(data::AbstractArray{T}) where T <: Number
+function default_header(data::AbstractArray{T}) where T <: Number
     # assigning keys
     hdu_keys = ["SIMPLE",
                 "BITPIX",

--- a/src/header.jl
+++ b/src/header.jl
@@ -433,12 +433,12 @@ function get_default_header(data::AbstractArray{T}) where T <: Number
     hdu_keys = ["SIMPLE",
                 "BITPIX",
                 "NAXIS",
-                [string(Symbol("NAXIS", i)) for i in 1:ndims(data)]...,
+                ("NAXIS$i" for i in 1:ndims(data))...,
                 "EXTEND"]
 
     # assiging values
     hdu_values = [true,                                           # SIMPLE
-                  FITSIO.Libcfitsio.bitpix_from_type(T),          # BITPIX
+                  Libcfitsio.bitpix_from_type(T),          # BITPIX
                   ndims(data),                                    # NAXIS
                   reverse(size(data))...,                         # size of each axis
                   true]                                           # EXTEND
@@ -447,7 +447,7 @@ function get_default_header(data::AbstractArray{T}) where T <: Number
     comments = ["file does conform to FITS standard",                                   # comment for SIMPLE
                 "number of bits per data pixel",                                        # comment for BITPIX
                 "number of data axes",                                                  # comment for NAXIS
-                [string(Symbol("length of data axis ", i)) for i in 1:ndims(data)]...,  # comments for axis length
+                ("length of data axis $i" for i in 1:ndims(data))...,  # comments for axis length
                 "FITS dataset may contain extensions"]                                  # comment for EXTEND
 
     return FITSHeader(hdu_keys, hdu_values, comments)

--- a/src/header.jl
+++ b/src/header.jl
@@ -438,7 +438,7 @@ function default_header(data::AbstractArray{T}) where T <: Number
 
     # assiging values
     hdu_values = [true,                                           # SIMPLE
-                  Libcfitsio.bitpix_from_type(T),                 # BITPIX
+                  CFITSIO.bitpix_from_type(T),                    # BITPIX
                   ndims(data),                                    # NAXIS
                   reverse(size(data))...,                         # size of each axis
                   true]                                           # EXTEND

--- a/src/header.jl
+++ b/src/header.jl
@@ -422,3 +422,33 @@ function show(io::IO, hdr::FITSHeader)
         i != n && println(io)
     end
 end
+
+"""
+    get_default_header(data::AbstractArray)
+
+Creates a default header from an `AbstractArray` with fields being `SIMPLE`, `BITPIX`, `NAXIS`, axis lengths and `EXTEND`.
+"""
+function get_default_header(data::AbstractArray{T}) where T <: Number
+    # assigning keys
+    hdu_keys = ["SIMPLE",
+                "BITPIX",
+                "NAXIS",
+                [string(Symbol("NAXIS", i)) for i in 1:ndims(data)]...,
+                "EXTEND"]
+
+    # assiging values
+    hdu_values = [true,                                           # SIMPLE
+                  FITSIO.Libcfitsio.bitpix_from_type(T),          # BITPIX
+                  ndims(data),                                    # NAXIS
+                  reverse(size(data))...,                         # size of each axis
+                  true]                                           # EXTEND
+
+    # assigning comments
+    comments = ["file does conform to FITS standard",                                   # comment for SIMPLE
+                "number of bits per data pixel",                                        # comment for BITPIX
+                "number of data axes",                                                  # comment for NAXIS
+                [string(Symbol("length of data axis ", i)) for i in 1:ndims(data)]...,  # comments for axis length
+                "FITS dataset may contain extensions"]                                  # comment for EXTEND
+
+    return FITSHeader(hdu_keys, hdu_values, comments)
+end

--- a/src/header.jl
+++ b/src/header.jl
@@ -438,7 +438,7 @@ function get_default_header(data::AbstractArray{T}) where T <: Number
 
     # assiging values
     hdu_values = [true,                                           # SIMPLE
-                  Libcfitsio.bitpix_from_type(T),          # BITPIX
+                  Libcfitsio.bitpix_from_type(T),                 # BITPIX
                   ndims(data),                                    # NAXIS
                   reverse(size(data))...,                         # size of each axis
                   true]                                           # EXTEND
@@ -447,7 +447,7 @@ function get_default_header(data::AbstractArray{T}) where T <: Number
     comments = ["file does conform to FITS standard",                                   # comment for SIMPLE
                 "number of bits per data pixel",                                        # comment for BITPIX
                 "number of data axes",                                                  # comment for NAXIS
-                ("length of data axis $i" for i in 1:ndims(data))...,  # comments for axis length
+                ("length of data axis $i" for i in 1:ndims(data))...,                   # comments for axis length
                 "FITS dataset may contain extensions"]                                  # comment for EXTEND
 
     return FITSHeader(hdu_keys, hdu_values, comments)

--- a/src/header.jl
+++ b/src/header.jl
@@ -426,7 +426,7 @@ end
 """
     get_default_header(data::AbstractArray)
 
-Creates a default header from an `AbstractArray` with fields being `SIMPLE`, `BITPIX`, `NAXIS`, axis lengths and `EXTEND`.
+Creates a default header for the given array with the `SIMPLE`, `BITPIX`, `NAXIS`, `NAXIS*`, and `EXTEND` entries.
 """
 function get_default_header(data::AbstractArray{T}) where T <: Number
     # assigning keys

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -566,9 +566,9 @@ HISTORY this is a history"""
     close(f)
     rm(fname, force=true)
 
-    # Test for get_default_header
+    # Test for default_header
     data = fill(Int16(2), 5, 6, 2)
-    hdr = get_default_header(data)
+    hdr = default_header(data)
     @test hdr isa FITSHeader
     @test hdr["SIMPLE"] == true
     @test hdr["BITPIX"] == 16

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,7 +155,7 @@ using Random # for `randstring`
                     b_view = @view b[:,:]
                     read!(f[1],b_view)
                     @test a == b
-                    
+
                     b_view = @view b3D[:,:,:]
                     read!(f[2],b_view)
                     @test a3D == b3D
@@ -171,7 +171,7 @@ using Random # for `randstring`
                         # Non-contiguous views can not be read into
                         b .= zero(eltype(b))
                         b_view = @view b[1,:]
-                        @test_throws ArgumentError read!(f[1],b_view,1,:)    
+                        @test_throws ArgumentError read!(f[1],b_view,1,:)
                     end
 
                     @testset "1D slices of a 3D array" begin
@@ -316,7 +316,7 @@ using Random # for `randstring`
                 rm(fname)
             end
         end
-            
+
         @testset "1D slice of a 3D array" begin
             try
                 FITS(fname,"r+") do f
@@ -337,7 +337,7 @@ using Random # for `randstring`
                 FITS(fname,"r+") do f
                     b_view = @view b[:,1,:]
                     @test_throws ArgumentError write(f,b_view)
-                    
+
                     b_view = @view b[1,:,:]
                     @test_throws ArgumentError write(f,b_view)
 
@@ -565,6 +565,18 @@ HISTORY this is a history"""
     # Clean up from last test.
     close(f)
     rm(fname, force=true)
+
+    # Test for get_default_header
+    data = fill(Int16(2), 5, 6, 2)
+    hdr = get_default_header(data)
+    @test hdr isa FITSHeader
+    @test hdr["SIMPLE"] == true
+    @test hdr["BITPIX"] == 16
+    @test hdr["NAXIS"] == 3
+    @test hdr["NAXIS1"] == 2
+    @test hdr["NAXIS2"] == 6
+    @test hdr["NAXIS3"] == 5
+    @test hdr["EXTEND"] == true
 end
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Added this method to get default header of an `AbstractArray`, it is being used in `CCDReduction.jl` to create `CCDData` directly from an `AbstractArray`. E. g.
```
CCDData(data::AbstractArray) = CCDData(data, get_default_header(data))
```