### PR TITLE
minor readme fix and bumped version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FITSIO"
 uuid = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
-version = "0.16.1"
+version = "0.16.2"
 
 [deps]
 CFITSIO = "3b1b4be9-1499-4b22-8d78-7db3344d1961"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Flexible Image Transport System (FITS) support for Julia
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliahci.github.io/FITSIO.jl/dev)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**Note:** The `Libcfitsio` submodule has been moved to [CFITSIO.jl](https://github.com/JuliaAstro/CFITSIO.jl) and will be deprecated in a futre release.
+**Note:** The `Libcfitsio` submodule has been moved to [CFITSIO.jl](https://github.com/JuliaAstro/CFITSIO.jl) and will be deprecated in a future release.
 
 
 ## Usage


### PR DESCRIPTION
The version was incremented to v0.16.2 to use the `default_header` in `CCDReduction.jl`