### PR TITLE
Add fitsread and fitswrite

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -26,9 +26,12 @@ set_comment!
 ## Image operations
 
 ```@docs
-write{T}(::FITS, ::Array{T})
-write{T}(::ImageHDU, ::Array{T})
 read(::ImageHDU)
+read!
+FITSIO.fitsread
+write(::FITS, ::StridedArray{<:Real})
+write(::ImageHDU, ::StridedArray{<:Real})
+FITSIO.fitswrite
 ndims(::ImageHDU)
 size(::ImageHDU)
 length(::ImageHDU)

--- a/src/header.jl
+++ b/src/header.jl
@@ -274,6 +274,24 @@ end
 
 
 """
+    read_header(filename::AbstractString, hduindex = 1) -> FITSHeader
+
+Convenience function to read the entire header corresponding to the HDU at index `hduindex` contained 
+in the FITS file named `filename`. Functionally `read_header(filename, hduindex)` is equivalent to
+
+```julia
+FITS(filename, "r") do f
+    read_header(f[hduindex])
+end
+```
+"""
+function read_header(filename::AbstractString, hduindex = 1)
+    FITS(filename, "r") do f
+        read_header(f[hduindex])
+    end
+end
+
+"""
     read_header(hdu::HDU) -> FITSHeader
 
 Read the entire header from the given HDU and return a `FITSHeader` object.

--- a/src/image.jl
+++ b/src/image.jl
@@ -68,6 +68,12 @@ length(hdu::ImageHDU) = prod(size(hdu))
 # when ndim != 1, rather than no method.
 lastindex(hdu::ImageHDU) = length(hdu::ImageHDU)
 
+function fitsread(filename, hduindex = 1, arrayinds...)
+    FITS(filename, "r") do f
+        read(f[hduindex], arrayinds...)
+    end
+end
+
 # Read a full image from an HDU
 """
     read(hdu::ImageHDU)
@@ -260,6 +266,12 @@ read(hdu::ImageHDU, I::Int...) = read_internal(hdu, I...)[1]
 read!(hdu::ImageHDU, array::StridedArray, I::Union{AbstractRange{Int}, Int, Colon}...) =
     read_internal!(hdu, array, I...)
 read!(hdu::ImageHDU, array::StridedArray, I::Int...) = read_internal!(hdu, array, I...)[1]
+
+function fitswrite(filename, data; kwargs...)
+    FITS(filename, "w") do f
+        write(f, data; kwargs...)
+    end
+end
 
 """
     write(f::FITS, data::StridedArray; header=nothing, name=nothing, ver=nothing)

--- a/src/table.jl
+++ b/src/table.jl
@@ -486,7 +486,7 @@ end
 
 
 """
-    read(hdu, colname; case_sensitive=true)
+    read(hdu::TableHDU, colname; case_sensitive=true)
 
 Read a column as an array from the given table HDU.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,77 +5,81 @@ using CFITSIO
 using Test
 using Random # for `randstring`
 
+randomfilename(dir) = joinpath(dir, randstring(12)*".fits")
+function tempnamefits(f)
+    mktempdir() do dir
+        f(randomfilename(dir))
+    end
+end
+
 @testset "Images" begin
     # Create a FITS instance and loop over supported types.
-    fname = tempname() * ".fits"
-    FITS(fname, "w") do f
-        for T in (UInt8, Int8, UInt16, Int16, UInt32, Int32, Int64,
-                  Float32, Float64)
-            indata = reshape(T[1:100;], 5, 20)
+    tempnamefits() do fname
+        FITS(fname, "w") do f
+            for T in (UInt8, Int8, UInt16, Int16, UInt32, Int32, Int64,
+                      Float32, Float64)
+                indata = reshape(T[1:100;], 5, 20)
 
-            # Test writing the data to a new extension
-            write(f, indata)
+                # Test writing the data to a new extension
+                write(f, indata)
 
-            # test reading the full array
-            outdata = read(f[end])
-            @test indata == outdata
-            @test eltype(indata) == eltype(outdata) == eltype(f[end])
+                # test reading the full array
+                outdata = read(f[end])
+                @test indata == outdata
+                @test eltype(indata) == eltype(outdata) == eltype(f[end])
 
-            # test reading subsets of the array
-            @test read(f[end], :, :) == indata
-            @test read(f[end], 4, 1:10) == indata[4, 1:10]  # 2-d array
-            @test read(f[end], :, 4) == indata[:, 4]  # 1-d array
-            @test read(f[end], 2, 3) == indata[2, 3]  # scalar
-            @test read(f[end], :, 1:2:10) == indata[:, 1:2:10]
-            @test read(f[end], 1:3, :) == indata[1:3, :]
+                # test reading subsets of the array
+                @test read(f[end], :, :) == indata
+                @test read(f[end], 4, 1:10) == indata[4, 1:10]  # 2-d array
+                @test read(f[end], :, 4) == indata[:, 4]  # 1-d array
+                @test read(f[end], 2, 3) == indata[2, 3]  # scalar
+                @test read(f[end], :, 1:2:10) == indata[:, 1:2:10]
+                @test read(f[end], 1:3, :) == indata[1:3, :]
 
-            # test expected errors
-            @test_throws DimensionMismatch read(f[end], :)
-            @test_throws DimensionMismatch read(f[end], :, :, 1)
-            @test_throws BoundsError read(f[end], 1:6, :)
-            @test_throws BoundsError read(f[end], 1, 0)
+                # test expected errors
+                @test_throws DimensionMismatch read(f[end], :)
+                @test_throws DimensionMismatch read(f[end], :, :, 1)
+                @test_throws BoundsError read(f[end], 1:6, :)
+                @test_throws BoundsError read(f[end], 1, 0)
 
-        end
+            end
 
-        @test_throws ErrorException f[100]
+            @test_throws ErrorException f[100]
 
-        # Test representation
-        @test repr(f)[end-17:end] == "9          Image  "
-        @test repr(f[1])[1:6] == "File: "
+            # Test representation
+            @test repr(f)[end-17:end] == "9          Image  "
+            @test repr(f[1])[1:6] == "File: "
 
-        # test iteration
-        for hdu in f
-            @test size(hdu) == (5, 20)
+            # test iteration
+            for hdu in f
+                @test size(hdu) == (5, 20)
+            end
         end
     end
-    rm(fname, force=true)
 
-    # copy_section()
-    fname1 = tempname() * ".fits"
-    fname2 = tempname() * ".fits"
-    try
-        f1 = FITS(fname1, "w")
-        indata = reshape(Float32[1:400;], 20, 20)
-        write(f1, indata)
+    @testset "copy_section" begin
+        mktempdir() do dir
+            fname1 = randomfilename(dir)
+            FITS(fname1, "w") do f1
+                indata = reshape(Float32[1:400;], 20, 20)
+                write(f1, indata)
 
-        f2 = FITS(fname2, "w")
-        copy_section(f1[1], f2, 1:10, 1:10)
-        copy_section(f1[1], f2, 1:10, 1:2:20)
-        outdata = read(f2[1])
-        @test outdata == indata[1:10, 1:10]
-        outdata = read(f2[2])
-        @test outdata == indata[1:10, 1:2:20]
-        close(f1)
-        close(f2)
-    finally
-        rm(fname1, force=true)
-        rm(fname2, force=true)
+                fname2 = randomfilename(dir)
+                FITS(fname2, "w") do f2
+                    copy_section(f1[1], f2, 1:10, 1:10)
+                    copy_section(f1[1], f2, 1:10, 1:2:20)
+                    outdata = read(f2[1])
+                    @test outdata == indata[1:10, 1:10]
+                    outdata = read(f2[2])
+                    @test outdata == indata[1:10, 1:2:20]
+                end
+            end
+        end
     end
 
     @testset "non-allocating read" begin
-        fname1 = tempname() * ".fits"
-        try
-            FITS(fname1, "r+") do f
+        tempnamefits() do fname
+            FITS(fname, "r+") do f
 
                 indata = reshape(Float32[1:400;], 20, 20)
                 write(f, indata)
@@ -216,110 +220,102 @@ using Random # for `randstring`
                     end
                 end
             end
-        finally
-            rm(fname1, force=true)
         end
     end
 
     @testset "reinterpreted complex" begin
         @testset "read" begin
-            fname = tempname() * ".fits"
-
-            function _testreadcomplex(arr::AbstractArray{Complex{T}}) where T
+            function _testreadcomplex(fname, arr::AbstractArray{Complex{T}}) where T
                 FITS(fname,"w") do f
-                    write(f, collect(reinterpret(T,arr)) )
+                    write(f, reinterpret(T,arr))
                 end
+
                 b = similar(arr)
                 FITS(fname,"r") do f
                     read!(f[1], reinterpret(T,b))
                 end
                 @test b == arr
+
                 c = FITS(fname,"r") do f
                     read(f[1])
                 end
                 @test c == reinterpret(T,arr)
             end
 
-            function testreadcomplex(arr::Array{Complex{T}}) where T
+            function testreadcomplex(fname, arr)
                 # Given a complex array, reinterpret it as float and write to file
                 # Read it back and compare
-                _testreadcomplex(arr)
+                _testreadcomplex(fname, arr)
 
                 # Write a contiguous subsection instead of the entire array
                 region = 1:size(arr,1)
                 arrv = @view arr[region]
-                _testreadcomplex(arrv)
+                _testreadcomplex(fname, arrv)
             end
 
-            try
-                testreadcomplex(ones(ComplexF64,3))
-                testreadcomplex(ones(ComplexF64,3,4))
-                testreadcomplex(ones(ComplexF64,3,4,5))
-            finally
-                rm(fname,force=true)
+            tempnamefits() do fname
+                testreadcomplex(fname, ones(ComplexF64,3))
+                testreadcomplex(fname, ones(ComplexF64,3,4))
+                testreadcomplex(fname, ones(ComplexF64,3,4,5))
             end
         end
 
         @testset "write" begin
-            fname = tempname() * ".fits"
-
-            function _testwritecomplex(arr::AbstractArray{Complex{T}}) where T
+            function _testwritecomplex(fname, arr::AbstractArray{Complex{T}}) where T
                 FITS(fname,"w") do f
                     write(f, reinterpret(T,arr) )
                 end
+
                 a = FITS(fname,"r") do f
                     read(f[1])
                 end
-                b = collect(reinterpret(T,arr))
+                
+                b = reinterpret(T,arr)
                 @test b == a
+                
                 c = FITS(fname,"r") do f
-                    reinterpret(Complex{T},read(f[1]))
+                    reinterpret(Complex{T}, read(f[1]))
                 end
                 @test c == arr
             end
 
-            function testwritecomplex(arr::Array{Complex{T}}) where T
+            function testwritecomplex(fname, arr)
                 # Given a complex array, reinterpret it as float and write to file
                 # Read it back and compare
-                _testwritecomplex(arr)
+                _testwritecomplex(fname, arr)
 
                 # Write a subsection instead of the entire array
                 region = 1:size(arr,1)
                 arrv = @view arr[region]
-                _testwritecomplex(arrv)
+                _testwritecomplex(fname, arrv)
             end
 
-            try
-                testwritecomplex(ones(ComplexF64,3))
-                testwritecomplex(ones(ComplexF64,3,4))
-                testwritecomplex(ones(ComplexF64,3,4,5))
-            finally
-                rm(fname,force=true)
+            tempnamefits() do fname
+                testwritecomplex(fname, ones(ComplexF64,3))
+                testwritecomplex(fname, ones(ComplexF64,3,4))
+                testwritecomplex(fname, ones(ComplexF64,3,4,5))
             end
         end
     end
 
     @testset "write views to file" begin
-        fname = tempname() * ".fits"
-        b = reshape([1:8;],2,2,2)
+        b = reshape([1:8;], 2, 2, 2)
 
         @testset "2D slice of a 3D array" begin
-            try
-                FITS(fname,"r+") do f
+            tempnamefits() do fname
+                FITS(fname, "r+") do f
                     for (ind,ax3) in enumerate(axes(b,3))
                         b_view = @view b[:,:,ax3]
                         write(f,b_view)
                         @test read(f[ind]) == b_view
                     end
                 end
-            finally
-                rm(fname)
             end
         end
 
         @testset "1D slice of a 3D array" begin
-            try
-                FITS(fname,"r+") do f
+            tempnamefits() do fname
+                FITS(fname, "r+") do f
                     ax23iter = Iterators.product(axes(b)[2:3]...)
                     for (ind,(ax2,ax3)) in enumerate(ax23iter)
                         b_view = @view b[:,ax2,ax3]
@@ -327,14 +323,12 @@ using Random # for `randstring`
                         @test read(f[ind]) == b_view
                     end
                 end
-            finally
-                rm(fname)
             end
         end
 
         @testset "Non-contiguous" begin
-            try
-                FITS(fname,"r+") do f
+            tempnamefits() do fname
+                FITS(fname, "r+") do f
                     b_view = @view b[:,1,:]
                     @test_throws ArgumentError write(f,b_view)
 
@@ -350,23 +344,19 @@ using Random # for `randstring`
                     # write something random to avoid the error on closing
                     write(f,zeros(1))
                 end
-            finally
-                rm(fname)
             end
         end
     end
 
     @testset "fitsread" begin
-        fname = tempname() * ".fits"
         a = ones(3,3)
-        try
+        
+        tempnamefits() do fname
             FITS(fname, "w") do f
                 write(f, a)
             end
             @test FITSIO.fitsread(fname) == a
             @test FITSIO.fitsread(fname, 1) == a
-        finally
-            rm(fname, force=true)
         end
     end
 end
@@ -374,160 +364,155 @@ end
 @testset "Write data to an existing image HDU" begin
     @testset "Overwrite an image" begin
         # Create a file with two images
-        fname = tempname() * ".fits"
-        FITS(fname, "w") do f
-            write(f, [[1 2 3]; [4 5 6]])
-            write(f, [[7 8 9]; [17 52 10]])
+        tempnamefits() do fname
+            
+            FITS(fname, "w") do f
+                write(f, [[1 2 3]; [4 5 6]])
+                write(f, [[7 8 9]; [17 52 10]])
+            end
+
+            # Open the file in read-write mode
+            FITS(fname, "r+") do f
+                @test read(f[1]) == [[1 2 3]; [4 5 6]]
+                @test read(f[2]) == [[7 8 9]; [17 52 10]]
+
+                # Write data into the first image HDU
+                write(f[1], [[11 12 13]; [14 15 16]])
+
+                @test read(f[1]) == [[11 12 13]; [14 15 16]]  # First HDU is updated
+                @test read(f[2]) == [[7 8 9]; [17 52 10]]  # Second HDU is untouched
+            end
         end
-
-        # Open the file in read-write mode
-        FITS(fname, "r+") do f
-            @test read(f[1]) == [[1 2 3]; [4 5 6]]
-            @test read(f[2]) == [[7 8 9]; [17 52 10]]
-
-            # Write data into the first image HDU
-            write(f[1], [[11 12 13]; [14 15 16]])
-
-            @test read(f[1]) == [[11 12 13]; [14 15 16]]  # First HDU is updated
-            @test read(f[2]) == [[7 8 9]; [17 52 10]]  # Second HDU is untouched
-        end
-
-        rm(fname, force=true)
     end
 
     @testset "Show size mismatch error" begin
-        fname = tempname() * ".fits"
-        FITS(fname, "w") do f
-            write(f, [[1 2 3 4]; [5 6 7 8]])
-            write(f, [[1 2 3]; [4 5 6]])
+        tempnamefits() do fname
+            FITS(fname, "w") do f
+                write(f, [[1 2 3 4]; [5 6 7 8]])
+                write(f, [[1 2 3]; [4 5 6]])
+            end
+
+            FITS(fname, "r+") do f
+                second_hdu = f[2]  # Get the second HDU
+
+                # Make the first HDU to be the current HDU
+                # Needed to check if `write` method compares data size with the given HDU
+                # and not with the current HDU
+                fits_movabs_hdu(f.fitsfile, 1)
+
+                # Attempt to write data array of incorrect size to the second HDU
+                exception = ErrorException("size of HDU [2, 3] not equal to size of data [2, 4].")
+                @test_throws exception write(second_hdu, [[11 12 13 14]; [15 16 17 18]])
+            end
         end
-
-        FITS(fname, "r+") do f
-            second_hdu = f[2]  # Get the second HDU
-
-            # Make the first HDU to be the current HDU
-            # Needed to check if `write` method compares data size with the given HDU
-            # and not with the current HDU
-            fits_movabs_hdu(f.fitsfile, 1)
-
-            # Attempt to write data array of incorrect size to the second HDU
-            exception = ErrorException("size of HDU [2, 3] not equal to size of data [2, 4].")
-            @test_throws exception write(second_hdu, [[11 12 13 14]; [15 16 17 18]])
-        end
-
-        rm(fname, force=true)
     end
 
     @testset "fitswrite" begin
-        fname = tempname() * ".fits"
-        a = ones(3,3)
-        try
+        tempnamefits() do fname
+            a = ones(3,3)
             FITSIO.fitswrite(fname, a)
             FITS(fname, "r") do f
                 @test read(f[1]) == a
             end
-        finally
-            rm(fname, force=true)
         end
     end
 end
 
 @testset "Tables" begin
-    fname = tempname() * ".fits"
-    f = FITS(fname, "w")
+    tempnamefits() do fname
+        FITS(fname, "w") do f
+            ## Binary table
+            indata = Dict{String, Array}()
+            for (i, T) in enumerate([UInt8, Int8, UInt16, Int16, UInt32, Int32, Int64,
+                                     Float32, Float64, ComplexF32, ComplexF64])
+                indata["col$i"] = T[1:20;]
+            end
+            i = length(indata) + 1
+            indata["col$i"] = [randstring(10) for j=1:20]  # ASCIIString column
+            i += 1
+            indata["col$i"] = ones(Bool, 20)  # Bool column
+            i += 1
+            indata["col$i"] = reshape([1:40;], (2, 20))  # vector Int64 column
+            i += 1
+            indata["col$i"] = [randstring(5) for j=1:2, k=1:20]  # vector ASCIIString col
+            indata["vcol"] = [randstring(j) for j=1:20]  # variable length column
+            indata["VCOL"] = [collect(1.:j) for j=1.:20.] # variable length
 
-    ## Binary table
-    indata = Dict{String, Array}()
-    for (i, T) in enumerate([UInt8, Int8, UInt16, Int16, UInt32, Int32, Int64,
-                             Float32, Float64, ComplexF32, ComplexF64])
-        indata["col$i"] = T[1:20;]
+            # test writing
+            write(f, indata; varcols=["vcol", "VCOL"])
+
+            # test reading
+            colnames = FITSIO.colnames(f[2])
+            for (colname, incol) in indata
+                outcol = read(f[2], colname)  # table is in extension 2 (1 = primary hdr)
+                @test outcol == incol
+                @test eltype(outcol) == eltype(incol)
+                @test colname in colnames
+            end
+
+            # TODO: remove the tests for deprecation warnings when we don't issue them, but keep the
+            # `@test_throws` test.
+            @test_throws ErrorException @test_nowarn(read(f[2], "vcol", case_sensitive=false))
+            @test_nowarn read(f[2], "col2")
+            @test_logs (:warn, r"case_sensitive") read(f[2], "COL2")
+
+            # Test representation
+            @test repr(f[2])[end-38:end] == "\n\n         (*) = variable-length column"
+
+            ## ASCII tables
+
+            indata = Dict{String, Array}()
+            for (i, T) in enumerate([Int16, Int32, Float32, Float64])
+                indata["col$i"] = T[1:20;]
+            end
+            i = length(indata) + 1
+            indata["col$i"] = [randstring(10) for j=1:20]
+
+            write(f, indata; hdutype=ASCIITableHDU)
+
+            # For ASCII tables, the types don't round trip so we need to define the
+            # expected output type for each input type.
+            expected_type = Dict(Int16=>Int32, Int32=>Int32,
+                                 Float32=>Float64, Float64=>Float64,
+                                 String=>String)
+            colnames = FITSIO.colnames(f[3])
+            for (colname, incol) in indata
+                outcol = read(f[3], colname)  # table is in extension 3
+                @test outcol == incol
+                @test eltype(outcol) == expected_type[eltype(incol)]
+                @test colname in colnames
+            end
+            # test show/repr on ASCIITableHDU by checking that a couple lines are what we expect
+            lines = split(repr(f[3]), "\n")
+            @test lines[4] == "Rows: 20"
+            @test lines[6] == "         col3  Float64  E26.17  "
+        end
     end
-    i = length(indata) + 1
-    indata["col$i"] = [randstring(10) for j=1:20]  # ASCIIString column
-    i += 1
-    indata["col$i"] = ones(Bool, 20)  # Bool column
-    i += 1
-    indata["col$i"] = reshape([1:40;], (2, 20))  # vector Int64 column
-    i += 1
-    indata["col$i"] = [randstring(5) for j=1:2, k=1:20]  # vector ASCIIString col
-    indata["vcol"] = [randstring(j) for j=1:20]  # variable length column
-    indata["VCOL"] = [collect(1.:j) for j=1.:20.] # variable length
-
-    # test writing
-    write(f, indata; varcols=["vcol", "VCOL"])
-
-    # test reading
-    colnames = FITSIO.colnames(f[2])
-    for (colname, incol) in indata
-        outcol = read(f[2], colname)  # table is in extension 2 (1 = primary hdr)
-        @test outcol == incol
-        @test eltype(outcol) == eltype(incol)
-        @test colname in colnames
-    end
-
-    # TODO: remove the tests for deprecation warnings when we don't issue them, but keep the
-    # `@test_throws` test.
-    @test_throws ErrorException @test_nowarn(read(f[2], "vcol", case_sensitive=false))
-    @test_nowarn read(f[2], "col2")
-    @test_logs (:warn, r"case_sensitive") read(f[2], "COL2")
-
-    # Test representation
-    @test repr(f[2])[end-38:end] == "\n\n         (*) = variable-length column"
-
-    ## ASCII tables
-
-    indata = Dict{String, Array}()
-    for (i, T) in enumerate([Int16, Int32, Float32, Float64])
-        indata["col$i"] = T[1:20;]
-    end
-    i = length(indata) + 1
-    indata["col$i"] = [randstring(10) for j=1:20]
-
-    write(f, indata; hdutype=ASCIITableHDU)
-
-    # For ASCII tables, the types don't round trip so we need to define the
-    # expected output type for each input type.
-    expected_type = Dict(Int16=>Int32, Int32=>Int32,
-                         Float32=>Float64, Float64=>Float64,
-                         String=>String)
-    colnames = FITSIO.colnames(f[3])
-    for (colname, incol) in indata
-        outcol = read(f[3], colname)  # table is in extension 3
-        @test outcol == incol
-        @test eltype(outcol) == expected_type[eltype(incol)]
-        @test colname in colnames
-    end
-    # test show/repr on ASCIITableHDU by checking that a couple lines are what we expect
-    lines = split(repr(f[3]), "\n")
-    @test lines[4] == "Rows: 20"
-    @test lines[6] == "         col3  Float64  E26.17  "
-    close(f)
-    rm(fname, force=true)
 end
 
 @testset "FITSHeader" begin
-    fname = tempname() * ".fits"
-    f = FITS(fname, "w")
+    tempnamefits() do fname
+        FITS(fname, "w") do f
 
-    # test that show() works on an empty file and that the beginning and end
-    # arre what we expect.
-    s = repr(f)
-    @test s[1:6] == "File: "
-    @test s[end-7:end] == "No HDUs."
+            # test that show() works on an empty file and that the beginning and end
+            # arre what we expect.
+            s = repr(f)
+            @test s[1:6] == "File: "
+            @test s[end-7:end] == "No HDUs."
 
-    @test_throws ErrorException FITSHeader(["KEY1"], [1, 2, 3], ["comment 1", "comment 2"])
+            @test_throws ErrorException FITSHeader(["KEY1"], [1, 2, 3], ["comment 1", "comment 2"])
 
-    inhdr = FITSHeader(["FLTKEY", "INTKEY", "BOOLKEY", "STRKEY", "COMMENT",
-                        "HISTORY"],
-                       [1.0, 1, true, "string value", nothing, nothing],
-                       ["floating point keyword",
-                        "",
-                        "boolean keyword",
-                        "string value",
-                        "this is a comment",
-                        "this is a history"])
+            inhdr = FITSHeader(["FLTKEY", "INTKEY", "BOOLKEY", "STRKEY", "COMMENT",
+                                "HISTORY"],
+                               [1.0, 1, true, "string value", nothing, nothing],
+                               ["floating point keyword",
+                                "",
+                                "boolean keyword",
+                                "string value",
+                                "this is a comment",
+                                "this is a history"])
 
-    @test repr(inhdr) == """
+            @test repr(inhdr) == """
 FLTKEY  =                  1.0 / floating point keyword
 INTKEY  =                    1
 BOOLKEY =                    T / boolean keyword
@@ -535,86 +520,85 @@ STRKEY  =       'string value' / string value
 COMMENT this is a comment
 HISTORY this is a history"""
 
-    inhdr["INTKEY"] = 2  # test setting by key
-    inhdr[1] = 2.0  # test settting by index
-    set_comment!(inhdr, "INTKEY", "integer keyword") # test setting a comment
+            inhdr["INTKEY"] = 2  # test setting by key
+            inhdr[1] = 2.0  # test settting by index
+            set_comment!(inhdr, "INTKEY", "integer keyword") # test setting a comment
 
-    # Test reading possibly missing keyword
-    @test_throws KeyError inhdr["BADKEY"]
-    @test getkey(inhdr, "BADKEY", nothing) === nothing
-    @test getkey(inhdr, "INTKEY", nothing) == inhdr["INTKEY"]
+            # Test reading possibly missing keyword
+            @test_throws KeyError inhdr["BADKEY"]
+            @test getkey(inhdr, "BADKEY", nothing) === nothing
+            @test getkey(inhdr, "INTKEY", nothing) == inhdr["INTKEY"]
 
-    indata = reshape(Float32[1:100;], 5, 20)
-    write(f, indata; header=inhdr)
+            indata = reshape(Float32[1:100;], 5, 20)
+            write(f, indata; header=inhdr)
 
-    # Write a second block.
-    inhdr2 = deepcopy(inhdr)
-    inhdr2["INTKEY"] = 3 # Set it to a different value.
-    write(f, indata; header=inhdr2)
+            # Write a second block.
+            inhdr2 = deepcopy(inhdr)
+            inhdr2["INTKEY"] = 3 # Set it to a different value.
+            write(f, indata; header=inhdr2)
 
-    outhdr = read_header(f[1])
-    @test outhdr["FLTKEY"] === 2.0
-    @test outhdr["INTKEY"] === 2
-    @test outhdr["BOOLKEY"] === true
-    @test outhdr["STRKEY"] == "string value"
-    @test get_comment(outhdr, 13) == "this is a comment"
-    @test get_comment(outhdr, 14) == "this is a history"
-    @test length(outhdr) == 14
-    @test haskey(outhdr, "FLTKEY")
+            outhdr = read_header(f[1])
+            @test outhdr["FLTKEY"] === 2.0
+            @test outhdr["INTKEY"] === 2
+            @test outhdr["BOOLKEY"] === true
+            @test outhdr["STRKEY"] == "string value"
+            @test get_comment(outhdr, 13) == "this is a comment"
+            @test get_comment(outhdr, 14) == "this is a history"
+            @test length(outhdr) == 14
+            @test haskey(outhdr, "FLTKEY")
 
-    # Read entire header as a single string
-    s = read_header(f[1], String)
-    @test s[1:9] == "SIMPLE  ="  # all headers should start with this.
-    @test length(s) == (9 + length(inhdr)) * 80  # 9 lines = 8 default + "END"
+            # Read entire header as a single string
+            s = read_header(f[1], String)
+            @test s[1:9] == "SIMPLE  ="  # all headers should start with this.
+            @test length(s) == (9 + length(inhdr)) * 80  # 9 lines = 8 default + "END"
 
-    # Test to check that read_header gets the right block even after reading another.
-    s_reread = read_header(f[1])
-    s_reread = read_header(f[2])
-    s_reread = read_header(f[1], String)
-    @test s == s_reread
+            # Test to check that read_header gets the right block even after reading another.
+            s_reread = read_header(f[1])
+            s_reread = read_header(f[2])
+            s_reread = read_header(f[1], String)
+            @test s == s_reread
 
-    # update an existing keyword, and read it directly
-    write_key(f[1], "FLTKEY", 3.0)
-    @test read_key(f[1], 9) == ("FLTKEY", 3.0, "floating point keyword")
-    @test read_key(f[1], "FLTKEY") == (3.0, "floating point keyword")
+            # update an existing keyword, and read it directly
+            write_key(f[1], "FLTKEY", 3.0)
+            @test read_key(f[1], 9) == ("FLTKEY", 3.0, "floating point keyword")
+            @test read_key(f[1], "FLTKEY") == (3.0, "floating point keyword")
 
-    # Test appending a keyword, then modifying a keyword of different
-    # values with write_key()
-    for value in [1.0, "string value", 42, false, nothing]
-        write_key(f[1], "NEWKEY", value, "new key comment")
-        @test read_key(f[1], "NEWKEY") == (value, "new key comment")
-        @test read_key(f[1], 15) == ("NEWKEY", value, "new key comment")
+            # Test appending a keyword, then modifying a keyword of different
+            # values with write_key()
+            for value in [1.0, "string value", 42, false, nothing]
+                write_key(f[1], "NEWKEY", value, "new key comment")
+                @test read_key(f[1], "NEWKEY") == (value, "new key comment")
+                @test read_key(f[1], 15) == ("NEWKEY", value, "new key comment")
+            end
+
+            # Test that show() works and that the beginning of output is what we expect.
+            @test repr(f)[1:6] == "File: "
+
+        end
+
+        hdr = FITS(fname, "r") do f
+            read_header(f[1])
+        end
+        hdrfname = read_header(fname)
+        @test keys(hdr) == keys(hdrfname)
+        @test values(hdr) == values(hdrfname)
+        for k in keys(hdr)
+            @test get_comment(hdr, k) == get_comment(hdrfname, k)
+        end
     end
 
-    # Test that show() works and that the beginning of output is what we expect.
-    @test repr(f)[1:6] == "File: "
-
-    # Clean up from last test.
-    close(f)
-
-    hdr = FITS(fname, "r") do f
-        read_header(f[1])
+    @testset "default_header" begin
+        data = fill(Int16(2), 5, 6, 2)
+        hdr = default_header(data)
+        @test hdr isa FITSHeader
+        @test hdr["SIMPLE"] == true
+        @test hdr["BITPIX"] == 16
+        @test hdr["NAXIS"] == 3
+        @test hdr["NAXIS1"] == 2
+        @test hdr["NAXIS2"] == 6
+        @test hdr["NAXIS3"] == 5
+        @test hdr["EXTEND"] == true
     end
-    hdrfname = read_header(fname)
-    @test keys(hdr) == keys(hdrfname)
-    @test values(hdr) == values(hdrfname)
-    for k in keys(hdr)
-        @test get_comment(hdr, k) == get_comment(hdrfname, k)
-    end
-
-    rm(fname, force=true)
-
-    # Test for default_header
-    data = fill(Int16(2), 5, 6, 2)
-    hdr = default_header(data)
-    @test hdr isa FITSHeader
-    @test hdr["SIMPLE"] == true
-    @test hdr["BITPIX"] == 16
-    @test hdr["NAXIS"] == 3
-    @test hdr["NAXIS1"] == 2
-    @test hdr["NAXIS2"] == 6
-    @test hdr["NAXIS3"] == 5
-    @test hdr["EXTEND"] == true
 end
 
 # -----------------------------------------------------------------------------
@@ -631,64 +615,58 @@ function create_test_file(fname::AbstractString, header::String)
         error("length of header must be multiple of 80")
     end
 
-    f = open(fname, "w")
+    open(fname, "w") do f
 
-    stdhdr = "SIMPLE  =                    T / file does conform to FITS standard             BITPIX  =                  -64 / number of bits per data pixel                  NAXIS   =                    2 / number of data axes                            NAXIS1  =                   10 / length of data axis 1                          NAXIS2  =                   10 / length of data axis 2                          EXTEND  =                    T / FITS dataset may contain extensions            "
-    endline = "END                                                                             "
-    data = fill(0., (10, 10))  # 10x10 array of big-endian Float64 zeros
+        stdhdr = "SIMPLE  =                    T / file does conform to FITS standard             BITPIX  =                  -64 / number of bits per data pixel                  NAXIS   =                    2 / number of data axes                            NAXIS1  =                   10 / length of data axis 1                          NAXIS2  =                   10 / length of data axis 2                          EXTEND  =                    T / FITS dataset may contain extensions            "
+        endline = "END                                                                             "
+        data = fill(0., (10, 10))  # 10x10 array of big-endian Float64 zeros
 
-    # write header
-    write(f, stdhdr)
-    write(f, header)
-    write(f, endline)
+        # write header
+        write(f, stdhdr)
+        write(f, header)
+        write(f, endline)
 
-    # add padding
-    block_position = (length(stdhdr) + length(header) + length(endline)) % 2880
-    padding = (block_position == 0) ? 0 : 2880 - block_position
-    write(f, " "^padding)
+        # add padding
+        block_position = (length(stdhdr) + length(header) + length(endline)) % 2880
+        padding = (block_position == 0) ? 0 : 2880 - block_position
+        write(f, " "^padding)
 
-    # write data
-    write(f, data)
+        # write data
+        write(f, data)
 
-    # add padding
-    block_position = sizeof(data) % 2880
-    padding = (block_position == 0) ? 0 : 2880 - block_position
-    write(f, fill(0x00, (padding,)))
-
-    close(f)
+        # add padding
+        block_position = sizeof(data) % 2880
+        padding = (block_position == 0) ? 0 : 2880 - block_position
+        write(f, fill(0x00, (padding,)))
+    end
 end
 
 @testset "Non-standard keywords" begin
-    fname = tempname() * ".fits"
-    fname2 = tempname() * ".fits"
-    try
+    mktempdir() do dir
+        fname = randomfilename(dir)
         # Create a test file with a few non-standard keyword records
         header = "        Warning: CROTA2 is inaccurate due to considerable skew                  SKEW    =  1.9511305786508E+00,  1.9234924037208E+00 /Measure of skew           "
         create_test_file(fname, header)
 
         # check that we can read the header (and data).
-        f = FITS(fname)
-        hdr = read_header(f[1])
-        @test hdr["SKEW"] == "1.9511305786508E+00,"
-        @test get_comment(hdr, "SKEW") == "1.9234924037208E+00 /Measure of skew"
-        data = read(f[1])
-        @test data == zeros(10, 10)
-        close(f)
+        FITS(fname) do f
+            hdr = read_header(f[1])
+            @test hdr["SKEW"] == "1.9511305786508E+00,"
+            @test get_comment(hdr, "SKEW") == "1.9234924037208E+00 /Measure of skew"
+            data = read(f[1])
+            @test data == zeros(10, 10)
+        end
 
         # Test that we can read is at a memory backed file
-        f = FITS(read(fname))
-        hdr = read_header(f[1])
-        data = read(f[1])
-        @test data == zeros(10, 10)
-        close(f)
-
-        # test that we can write it back out.
-        f2 = FITS(fname2, "w")
-        write(f2, data; header=hdr)
-        close(f2)
-    finally
-        rm(fname, force=true)
-        rm(fname2, force=true)
+        FITS(read(fname)) do f
+            hdr = read_header(f[1])
+            data = read(f[1])
+            @test data == zeros(10, 10)
+            # test that we can write it back out.
+            FITS(randomfilename(dir), "w") do f2
+                write(f2, data; header=hdr)
+            end
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -591,6 +591,17 @@ HISTORY this is a history"""
 
     # Clean up from last test.
     close(f)
+
+    hdr = FITS(fname, "r") do f
+        read_header(f[1])
+    end
+    hdrfname = read_header(fname)
+    @test keys(hdr) == keys(hdrfname)
+    @test values(hdr) == values(hdrfname)
+    for k in keys(hdr)
+        @test get_comment(hdr, k) == get_comment(hdrfname, k)
+    end
+
     rm(fname, force=true)
 
     # Test for default_header

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -355,6 +355,20 @@ using Random # for `randstring`
             end
         end
     end
+
+    @testset "fitsread" begin
+        fname = tempname() * ".fits"
+        a = ones(3,3)
+        try
+            FITS(fname, "w") do f
+                write(f, a)
+            end
+            @test FITSIO.fitsread(fname) == a
+            @test FITSIO.fitsread(fname, 1) == a
+        finally
+            rm(fname, force=true)
+        end
+    end
 end
 
 @testset "Write data to an existing image HDU" begin
@@ -402,6 +416,19 @@ end
         end
 
         rm(fname, force=true)
+    end
+
+    @testset "fitswrite" begin
+        fname = tempname() * ".fits"
+        a = ones(3,3)
+        try
+            FITSIO.fitswrite(fname, a)
+            FITS(fname, "r") do f
+                @test read(f[1]) == a
+            end
+        finally
+            rm(fname, force=true)
+        end
     end
 end
 


### PR DESCRIPTION
These convenience functions are useful while working with images. Currently I find this pattern commonly used in my code:

```julia
FITS(filename, "r") do f
    read(f[1])
end
```
this may be replaced by 
```julia
fitsread(filename)
```

and similarly for writing as well. This is easier for REPL usage too.

Not sure if these should be exported (possible conflicts in case users have defined these themselves), so currently it's up to the users to import these.