### PR TITLE
Bugfix in exception type check in tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -452,7 +452,7 @@ end
 
             # TODO: remove the tests for deprecation warnings when we don't issue them, but keep the
             # `@test_throws` test.
-            @test_throws ErrorException @test_nowarn(read(f[2], "vcol", case_sensitive=false))
+            @test_throws Exception @test_nowarn(read(f[2], "vcol", case_sensitive=false))
             @test_nowarn read(f[2], "col2")
             @test_logs (:warn, r"case_sensitive") read(f[2], "COL2")
 


### PR DESCRIPTION
Since `CFITSIO.jl` has now introduced its own error type `CFITSIOError`, tests that checked for `ErrorException` specifically are failing. This PR fixes these (along with the [upstream fix](https://github.com/JuliaAstro/CFITSIO.jl/pull/5)). Tests appear to pass locally for me.

The CI will need to be re-triggered once the patch to `CFITSIO.jl` is released.