### PR TITLE
Add deleteat

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+FITSIO = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
 
 [compat]
 Documenter = "0.24"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -4,8 +4,9 @@
 
 ```@docs
 FITS
-length(::FITS)
-close(::FITS)
+length
+close
+deleteat!
 ```
 
 ## Header operations
@@ -21,6 +22,7 @@ keys(::FITSHeader)
 values(::FITSHeader)
 get_comment
 set_comment!
+default_header
 ```
 
 ## Image operations

--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -28,7 +28,8 @@ import Base: getindex,
              haskey,
              keys,
              values,
-             eltype
+             eltype,
+             deleteat!
 
 # Deal with compatibility issues.
 using Printf
@@ -48,6 +49,7 @@ import CFITSIO: FITSFile,
                 fits_write_pix,
                 fits_get_num_hdus,
                 fits_movabs_hdu,
+                fits_delete_hdu,
                 fits_get_img_size,
                 fits_get_img_type,
                 fits_get_img_equivtype,

--- a/src/fits.jl
+++ b/src/fits.jl
@@ -126,6 +126,24 @@ function getindex(f::FITS, name::AbstractString, ver::Int=0)
 end
 
 """
+    deleteat!(f::FITS, i::Integer)
+
+Delete the HDU at index `i` in the FITS file. If `i == 1`, this deletes the primary HDU and replaces it 
+with a bare HDU with no data and a minimal header. If `i > 1`, this removes the HDU at index `i`
+and moves the following HDUs forward.
+"""
+function deleteat!(f::FITS, i::Integer)
+    fits_assert_open(f.fitsfile)
+
+    if haskey(f.hdus, i)
+        delete!(f.hdus, i)
+    end
+    fits_movabs_hdu(f.fitsfile, i)
+    fits_delete_hdu(f.fitsfile)
+    f
+end
+
+"""
     close(f::FITS)
 
 Close the file.

--- a/src/fits.jl
+++ b/src/fits.jl
@@ -128,16 +128,14 @@ end
 """
     deleteat!(f::FITS, i::Integer)
 
-Delete the HDU at index `i` in the FITS file. If `i == 1`, this deletes the primary HDU and replaces it 
+Delete the HDU at index `i` in the FITS file. If `i == 1`, this deletes the primary HDU and replaces it
 with a bare HDU with no data and a minimal header. If `i > 1`, this removes the HDU at index `i`
 and moves the following HDUs forward.
 """
 function deleteat!(f::FITS, i::Integer)
     fits_assert_open(f.fitsfile)
 
-    if haskey(f.hdus, i)
-        delete!(f.hdus, i)
-    end
+    delete!(f.hdus, i)
     fits_movabs_hdu(f.fitsfile, i)
     fits_delete_hdu(f.fitsfile)
     f

--- a/src/header.jl
+++ b/src/header.jl
@@ -7,15 +7,17 @@
 # start with `fits_`.
 
 """
+    try_parse_hdrval(::Type, s::String)
+
 ```julia
 try_parse_hdrval(T, s) -> x::Union{T,Nothing}
 ```
 
 attempts to parse string `s` for a FITS card value of type `T` (`String`,
 `Bool`, `Int` or `Float64`) and yields either a value of type `T` or
-[`nothing`](@ref) if parsing is unsuccessful.
+`nothing` if parsing is unsuccessful.
 
-See also: [`tryparse`](@ref), [`parse_header_val`](@ref).
+See also: [`parse_header_val`](@ref).
 
 """
 function try_parse_hdrval(::Type{Bool}, s::String)
@@ -58,11 +60,9 @@ hdrval_repr(v::String) = @sprintf "'%s'" v
 hdrval_repr(v::Union{AbstractFloat, Integer}) = string(v)
 
 """
-```julia
-parse_header_val(s) -> x::Union{String,Bool,Int,Float64,Nothing}
-```
+    parse_header_val(s::String) -> x::Union{String,Bool,Int,Float64,Nothing}
 
-parses the FITS card value in the string `s` and returns a value of type
+Parse the FITS card value in the string `s` and return a value of type
 `String`, `Bool`, `Int`, `Float64` or `Nothing`.  The latter indicates an
 empty value.  This method never throws an error; if the value cannot be
 parsed it is returned as it.
@@ -89,12 +89,10 @@ function parse_header_val(s::String)
 end
 
 """
-```julia
-fits_try_read_keys(f, T, keys)
-```
+    fits_try_read_keys(f::FITSFile, ::Type{T}, keys)
 
-tries to read the raw FITS keys in given order if FITS handle `f` and
-returns a value of type `T` or [`nothing`](@ref) if no key exists or if
+Try to read the raw FITS keys in given order if FITS handle `f` and
+return a value of type `T` or [`nothing`](@ref) if no key exists or if
 parsing an existing key is unsuccessful.
 
 See also: [`try_parse_hdrval`](@ref).

--- a/src/header.jl
+++ b/src/header.jl
@@ -7,14 +7,10 @@
 # start with `fits_`.
 
 """
-    try_parse_hdrval(::Type, s::String)
+    try_parse_hdrval(T, s) -> x::Union{T,Nothing}
 
-```julia
-try_parse_hdrval(T, s) -> x::Union{T,Nothing}
-```
-
-attempts to parse string `s` for a FITS card value of type `T` (`String`,
-`Bool`, `Int` or `Float64`) and yields either a value of type `T` or
+Attempt to parse string `s` for a FITS card value of type `T` (`String`,
+`Bool`, `Int` or `Float64`) and yield either a value of type `T` or
 `nothing` if parsing is unsuccessful.
 
 See also: [`parse_header_val`](@ref).
@@ -220,20 +216,16 @@ end
 # Public API
 
 """
-```julia
-read_key(hdu::HDU, key::String) -> (value, comment)
-```
+    read_key(hdu::HDU, key::String) -> (value, comment)
 
-Reads the HDU header record specified by keyword and returns a tuple where
+Read the HDU header record specified by keyword and return a tuple where
 `value` is the keyword parsed value (of type `String`, `Bool`, `Int`,
 `Float64` or `Nothing`), `comment` is the keyword comment (as a string).
-An error is thrown if `key` is not found.
+Throw an error if `key` is not found.
 
-```julia
-read_key(hdu::HDU, key::Integer) -> (keyname, value, comment)
-```
+    read_key(hdu::HDU, key::Integer) -> (keyname, value, comment)
 
-same as above but FITS card is specified by its position and returns a 3
+Same as above but FITS card is specified by its position and returns a 3
 element tuple where `keyname` is the keyword name (a string).
 """
 function read_key(hdu::HDU, key::Integer)

--- a/src/image.jl
+++ b/src/image.jl
@@ -236,12 +236,15 @@ function read_internal!(hdu::ImageHDU, array::StridedArray,
     if !iscontiguous(array)
         throw(ArgumentError("the output array needs to be contiguous"))
     end
+
     # check number of indices and bounds. Note that number of indices and
     # array dimension must match, unlike in Arrays. Array-like behavior could
     # be supported in the future with care taken in constructing first, last,
     if length(I) != ndims(hdu)
         throw(DimensionMismatch("number of indices must match dimensions"))
     end
+
+    # The following require the HDU to be open
 
     fits_assert_open(hdu.fitsfile)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)

--- a/src/image.jl
+++ b/src/image.jl
@@ -236,15 +236,12 @@ function read_internal!(hdu::ImageHDU, array::StridedArray,
     if !iscontiguous(array)
         throw(ArgumentError("the output array needs to be contiguous"))
     end
-
     # check number of indices and bounds. Note that number of indices and
     # array dimension must match, unlike in Arrays. Array-like behavior could
     # be supported in the future with care taken in constructing first, last,
     if length(I) != ndims(hdu)
         throw(DimensionMismatch("number of indices must match dimensions"))
     end
-
-    # The following require the HDU to be open
 
     fits_assert_open(hdu.fitsfile)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -411,20 +411,28 @@ end
 
     @testset "delete" begin
         tempnamefits() do fname
-            f = FITS(fname, "w")
-            write(f, ones(2,2))
-            write(f, ones(3,3))
-            @test length(f) == 2
-            deleteat!(f, 2)
-            @test length(f) == 1
-            write(f, ones(3,3))
-            deleteat!(f,1)
-            @test length(f) == 2
-            @test ndims(f[1]) == 0
-            write(f, ones(4,4))
-            deleteat!(f, 2)
-            @test size(f[2]) == (4,4)
-            close(f)
+            FITS(fname, "w") do f
+                write(f, ones(2,2))
+                write(f, ones(3,3))
+                @test length(f) == 2
+                deleteat!(f, 2)
+                @test length(f) == 1
+
+                # if the array is read in before deletion,
+                # test that the hdu is removed from the cache
+                write(f, ones(3,3))
+                read(f[2])
+                deleteat!(f, 2)
+                @test length(f) == 1
+
+                write(f, ones(3,3))
+                deleteat!(f,1)
+                @test length(f) == 2
+                @test ndims(f[1]) == 0
+                write(f, ones(4,4))
+                deleteat!(f, 2)
+                @test size(f[2]) == (4,4)
+            end
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -408,6 +408,25 @@ end
             end
         end
     end
+
+    @testset "delete" begin
+        tempnamefits() do fname
+            f = FITS(fname, "w")
+            write(f, ones(2,2))
+            write(f, ones(3,3))
+            @test length(f) == 2
+            deleteat!(f, 2)
+            @test length(f) == 1
+            write(f, ones(3,3))
+            deleteat!(f,1)
+            @test length(f) == 2
+            @test ndims(f[1]) == 0
+            write(f, ones(4,4))
+            deleteat!(f, 2)
+            @test size(f[2]) == (4,4)
+            close(f)
+        end
+    end
 end
 
 @testset "Write data to an existing image HDU" begin


### PR DESCRIPTION
This PR depends on https://github.com/JuliaAstro/CFITSIO.jl/pull/6, where the function to delete an HDU is added. Now it's possible to remove an HDU from a FITS file.

```julia
julia> f = FITS(tempname() * ".fits", "w");

julia> write(f, ones(1,1))

julia> write(f, ones(2,2))

julia> write(f, ones(3,3))

julia> deleteat!(f, 2)
File: /tmp/jl_XeX9WX.fits
Mode: "w" (read-write)
HDUs: Num  Name  Type   
      1          Image  
      2          Image  

julia> size(f[2])
(3, 3)

julia> deleteat!(f, 1) # deleting the primary HDU recreates one with minimal metadata and no image
File: /tmp/jl_XeX9WX.fits
Mode: "w" (read-write)
HDUs: Num  Name  Type   
      1          Image  
      2          Image  

julia> size(f[1])
()

julia> size(f[2])
(3, 3)

```