### PR TITLE
Loosen signature of `ImageHDU` inner constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FITSIO"
 uuid = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
-version = "0.16.7"
+version = "0.16.8"
 
 [deps]
 CFITSIO = "3b1b4be9-1499-4b22-8d78-7db3344d1961"

--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -103,7 +103,7 @@ mutable struct ImageHDU{T<:Real,N} <: HDU
     fitsfile::FITSFile
     ext::Int
 
-    function ImageHDU(fitsfile::FITSFile, ext::Int)
+    function ImageHDU(fitsfile::FITSFile, ext::Integer)
         fits_assert_open(fitsfile)
         fits_movabs_hdu(fitsfile, ext)
         N = Int(fits_get_img_dim(fitsfile))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -383,6 +383,18 @@ end
             @test FITSIO.fitsread(fname, 1) == a
         end
     end
+
+    # Ref: https://github.com/JuliaAstro/FITSIO.jl/issues/163
+    @testset "String key" begin
+        a = ones(3,3)
+        tempnamefits() do fname
+            FITS(fname, "w") do f
+                write(f, a, name="a")
+                @test read(f["a"]) == a
+                @test read(f[1])   == a
+            end
+        end
+    end
 end
 
 @testset "Write data to an existing image HDU" begin


### PR DESCRIPTION
This restores the possibility of indexing an Image HDU with a string.

Fix #163.  CC: @jishnub @andrew-saydjari