### PR TITLE
Reduce allocations in read! if ndims don't match

### DIFF
--- a/src/image.jl
+++ b/src/image.jl
@@ -72,7 +72,7 @@ eltype(::ImageHDU{T}) where T = T
     fitsread(filename::AbstractString, hduindex = 1, arrayindices...)
 
 Convenience function to read in an image corresponding to the HDU at index `hduindex` contained in
-the FITS file named `filename`. 
+the FITS file named `filename`.
 If `arrayindices` are provided, only a slice of the image corresponding to the indices is read in.
 
 Functionally `fitsread(filename, hduindex, arrayindices...)` is equivalent to
@@ -84,7 +84,7 @@ end
 ```
 
 !!! note
-    Julia follows a column-major array indexing convention, so the indices provided must account for this. 
+    Julia follows a column-major array indexing convention, so the indices provided must account for this.
     In particular this means that FITS files created externally following a row-major convention (eg. using astropy)
     will have the sequence of axes flipped when read in using FITSIO.
 
@@ -103,12 +103,12 @@ end
 
 Read the data array or a subset thereof from disk. The first form
 reads the entire data array. The second form reads a slice of the array
-given by the specified ranges or integers. Dimensions specified by integers will be 
+given by the specified ranges or integers. Dimensions specified by integers will be
 dropped in the returned array, while those specified by ranges will be retained.
 
 !!! note
-    Julia follows a column-major array indexing convention, so the indices provided must account for this. 
-    In particular this means that FITS files created externally following a row-major convention (eg. using astropy) 
+    Julia follows a column-major array indexing convention, so the indices provided must account for this.
+    In particular this means that FITS files created externally following a row-major convention (eg. using astropy)
     will have the sequence of axes flipped when read in using FITSIO.
 """
 function read(hdu::ImageHDU)
@@ -120,7 +120,7 @@ function read(hdu::ImageHDU)
 end
 
 #= Inplace read
-This requires a contiguous array. Lacking a type to dispatch upon, 
+This requires a contiguous array. Lacking a type to dispatch upon,
 we rely on runtime checks.
 =#
 
@@ -140,15 +140,15 @@ checkcontiguous(::Tuple{},args...) = true
     read!(hdu::ImageHDU, A::StridedArray)
     read!(hdu::ImageHDU, A::StridedArray, range...)
 
-Read the data or a subset thereof from disk, and save it in a 
+Read the data or a subset thereof from disk, and save it in a
 pre-allocated output array `A`.
-The first form reads the entire data from disk. 
+The first form reads the entire data from disk.
 The second form reads a slice of the array given by the specified ranges or integers.
 The array `A` needs to have the same length as the number of elements to be read in.
 Additionally `A` needs to be stored contiguously in memory.
 
 !!! note
-    Julia follows a column-major array indexing convention, so the indices provided must account for this. 
+    Julia follows a column-major array indexing convention, so the indices provided must account for this.
     In particular this means that FITS files created externally following a row-major convention (eg. using astropy)
     will have the sequence of the axes flipped when read in using FITSIO.
 """
@@ -202,7 +202,7 @@ _index_shape_dim(sz, dim, r::AbstractRange) = (length(r),)
 
 # Read a subset of an ImageHDU
 function read_internal(hdu::ImageHDU, I::Union{AbstractRange{Int}, Integer, Colon}...)
-    
+
     # check number of indices and bounds. Note that number of indices and
     # array dimension must match, unlike in Arrays. Array-like behavior could
     # be supported in the future with care taken in constructing first, last,
@@ -230,7 +230,7 @@ function read_internal(hdu::ImageHDU, I::Union{AbstractRange{Int}, Integer, Colo
     data
 end
 
-function read_internal!(hdu::ImageHDU{T}, array::StridedArray{T}, 
+function read_internal!(hdu::ImageHDU{T}, array::StridedArray{T},
     I::Union{AbstractRange{Int}, Integer, Colon}...) where T
 
     if !iscontiguous(array)
@@ -245,7 +245,7 @@ function read_internal!(hdu::ImageHDU{T}, array::StridedArray{T},
 
     fits_assert_open(hdu.fitsfile)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
-    
+
     sz = size(hdu)
     for i = 1:ndims(hdu)
         _checkbounds(sz[i], I[i]) || throw(BoundsError())
@@ -311,7 +311,7 @@ The data to be written out must be stored contiguously in memory.
 
 !!! tip "Unsupported element types"
     It might be possible to write out an array with an element type other than those mentioned above
-    by `reinterpret`ing it as one that is supported. For example, to write out a `Complex` 
+    by `reinterpret`ing it as one that is supported. For example, to write out a `Complex`
     array and read it back in, we may use
 
     ```julia
@@ -330,7 +330,7 @@ The data to be written out must be stored contiguously in memory.
      0.2495752009567498 + 0.819163869249041im
     ```
 
-    While this often works in practice, such a workaround is not officially supported by FITSIO, 
+    While this often works in practice, such a workaround is not officially supported by FITSIO,
     and care must be taken to ensure the correctness of data.
 """
 function write(f::FITS, data::StridedArray{<:Real};
@@ -366,7 +366,7 @@ end
 """
     write(hdu::ImageHDU, data::StridedArray{<:Real})
 
-Write data to an existing image HDU. 
+Write data to an existing image HDU.
 The data to be written out must be stored contiguously in memory.
 """
 function write(hdu::ImageHDU{T}, data::StridedArray{T}) where T<:Real

--- a/src/image.jl
+++ b/src/image.jl
@@ -153,7 +153,8 @@ Additionally `A` needs to be stored contiguously in memory.
     will have the sequence of the axes flipped when read in using FITSIO.
 """
 function read!(hdu::ImageHDU{T}, array::StridedArray{T}) where {T<:Real}
-    read!(hdu, reshape(array, size(hdu)))
+    read!(hdu, reshape(array, Val(ndims(hdu))))
+    return array
 end
 function read!(hdu::ImageHDU{T,N}, array::StridedArray{T,N}) where {T<:Real,N}
 
@@ -169,7 +170,7 @@ function read!(hdu::ImageHDU{T,N}, array::StridedArray{T,N}) where {T<:Real,N}
     end
 
     fits_read_pix(hdu.fitsfile, array)
-    array
+    return array
 end
 
 # _checkbounds methods copied from Julia v0.4 Base.


### PR DESCRIPTION
The PR is best viewed by ignoring the whitespace fixes. The main changes are in https://github.com/JuliaAstro/FITSIO.jl/commit/f9445c755e89cad435393316c24789ec606dd5b1

On master
```julia
julia> f = tempname()
"/tmp/jl_06nrxc"

julia> FITSIO.fitswrite(f, Float64[1 2; 3 4]);

julia> ff = FITS(f, "r");

julia> v = zeros(4);

julia> @btime read!($(ff[1]), $v);
  640.083 ns (5 allocations: 384 bytes)
```

After this PR
```julia
julia> @btime read!($(ff[1]), $v);
  541.556 ns (4 allocations: 288 bytes)
```