### PR TITLE
relax eltypes in inplace read

### DIFF
--- a/src/image.jl
+++ b/src/image.jl
@@ -152,11 +152,10 @@ Additionally `A` needs to be stored contiguously in memory.
     In particular this means that FITS files created externally following a row-major convention (eg. using astropy)
     will have the sequence of the axes flipped when read in using FITSIO.
 """
-function read!(hdu::ImageHDU{T}, array::StridedArray{T}) where {T<:Real}
-    read!(hdu, reshape(array, Val(ndims(hdu))))
-    return array
+function read!(hdu::ImageHDU, array::StridedArray{<:Real})
+    read!(hdu, reshape(array, size(hdu)))
 end
-function read!(hdu::ImageHDU{T,N}, array::StridedArray{T,N}) where {T<:Real,N}
+function read!(hdu::ImageHDU{<:Real,N}, array::StridedArray{<:Real,N}) where {N}
 
     if !iscontiguous(array)
         throw(ArgumentError("the output array needs to be contiguous"))
@@ -231,8 +230,8 @@ function read_internal(hdu::ImageHDU, I::Union{AbstractRange{<:Integer}, Integer
     data
 end
 
-function read_internal!(hdu::ImageHDU{T}, array::StridedArray{T},
-    I::Union{AbstractRange{<:Integer}, Integer, Colon}...) where T
+function read_internal!(hdu::ImageHDU, array::StridedArray,
+    I::Union{AbstractRange{<:Integer}, Integer, Colon}...)
 
     if !iscontiguous(array)
         throw(ArgumentError("the output array needs to be contiguous"))
@@ -272,9 +271,9 @@ read(hdu::ImageHDU, I::Union{AbstractRange{<:Integer}, Integer, Colon}...) =
     read_internal(hdu, I...)
 read(hdu::ImageHDU, I::Integer...) = read_internal(hdu, I...)[1]
 
-read!(hdu::ImageHDU{T}, array::StridedArray{T}, I::Union{AbstractRange{<:Integer}, Integer, Colon}...) where T<:Real =
+read!(hdu::ImageHDU, array::StridedArray{<:Real}, I::Union{AbstractRange{<:Integer}, Integer, Colon}...) =
     read_internal!(hdu, array, I...)
-read!(hdu::ImageHDU{T}, array::StridedArray{T}, I::Integer...) where T<:Real = read_internal!(hdu, array, I...)[1]
+read!(hdu::ImageHDU, array::StridedArray{<:Real}, I::Integer...) = read_internal!(hdu, array, I...)[1]
 
 """
     fitswrite(filename::AbstractString, data; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,12 +144,12 @@ end
                 b = zeros(eltype(indata))
                 read!(f[1],b,1,1)
                 @test a[1,1] == first(b)
-
-                # Test for errors
-                b = zeros(Float64)
-                # Types must match
-                @test_throws MethodError read!(f[1],b,1,1)
-                @test_throws MethodError read!(f[1],b)
+                read!(f[2], b, 1, 1, 1)
+                @test a3D[1,1,1] == first(b)
+                # read the entire image into an array with a different eltype
+                b3D = zeros(size(a3D))
+                read!(f[2], b3D)
+                @test a3D == b3D
 
                 b = zeros(eltype(indata))
                 @test_throws DimensionMismatch read!(f[1],b,1:10,1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -158,6 +158,8 @@ end
                 @test_throws DimensionMismatch read!(f[1],b,:,1)
                 @test_throws DimensionMismatch read!(f[1],b,1,:)
                 @test_throws DimensionMismatch read!(f[1],b,:,:)
+                @test_throws DimensionMismatch read!(f[1], zeros(1,1))
+                @test_throws DimensionMismatch read!(f[1], zeros(1,1), :)
 
                 b3D = zero(indata3D)
                 read!(f[2],b3D)


### PR DESCRIPTION
The PR is best viewed by ignoring the whitespace fixes. The main change is in the various `read!` functions that now accept an array with an eltype different from that of the image. This is supported by cfitsio through an internal conversion.

After this PR
```julia
julia> f = tempname()
"/tmp/jl_ILWosZ"

julia> FITSIO.fitswrite(f, [1 2; 3 4]);

julia> m = zeros(2,2);

julia> ff = FITS(f, "r");

julia> read!(ff[1], m)
2×2 Matrix{Float64}:
 1.0  2.0
 3.0  4.0

julia> m
2×2 Matrix{Float64}:
 1.0  2.0
 3.0  4.0

julia> eltype(ff[1])
Int64
```

Here `Int64` data is read into a `Float64` array. This used to error on master.