### PR TITLE
Use ndims in size to reduce allocations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Aqua = "0.5"
-CFITSIO = "1"
+CFITSIO = "1.2"
 Reexport = "0.2, 1.0"
 Tables = "1"
 julia = "1.3"

--- a/src/image.jl
+++ b/src/image.jl
@@ -44,7 +44,7 @@ into memory.
 function size(hdu::ImageHDU{<:Any,N}) where N
     fits_assert_open(hdu.fitsfile)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
-    sz = fits_get_img_size(hdu.fitsfile)
+    sz = fits_get_img_size(hdu.fitsfile, Val(N))
     NTuple{N,Int}(sz)
 end
 

--- a/src/image.jl
+++ b/src/image.jl
@@ -349,7 +349,7 @@ function write(f::FITS, data::StridedArray{<:Real};
 
     s = size(data)
 
-    fits_create_img(f.fitsfile, eltype(data), [s...])
+    fits_create_img(f.fitsfile, eltype(data), s)
 
     if isa(header, FITSHeader)
         fits_write_header(f.fitsfile, header, true)
@@ -360,7 +360,7 @@ function write(f::FITS, data::StridedArray{<:Real};
     if isa(ver, Integer)
         fits_update_key(f.fitsfile, "EXTVER", ver)
     end
-    fits_write_pix(f.fitsfile, ones(Int, ndims(data)), length(data), data)
+    fits_write_pix(f.fitsfile, data)
     nothing
 end
 
@@ -391,7 +391,7 @@ function write(hdu::ImageHDU{T}, data::StridedArray{T}) where T<:Real
         error("size of HDU $(hdu_size) not equal to size of data $(data_size).")
     end
 
-    fits_write_pix(hdu.fitsfile, ones(Int, ndims(data)), length(data), data)
+    fits_write_pix(hdu.fitsfile, data)
     nothing
 end
 


### PR DESCRIPTION
This PR relies on https://github.com/JuliaAstro/CFITSIO.jl/pull/8, so tests will only pass with that PR merged and a version tagged.

On master and using the latest tagged CFITSIO:
```julia
julia> filename = tempname();

julia> FITSIO.fitswrite(filename, collect(reshape(1:10_000, 100, 100)));

julia> using BenchmarkTools

julia> g(f::FITS) = size(f[1]);  # runtime dispatch

julia> h(f::FITS) = size(f[1]::ImageHDU{Int,2}); # compile-time dispatch

julia> f = FITS(filename, "r");

julia> @btime g($f);
  161.138 ns (2 allocations: 128 bytes)

julia> @btime h($f);
  127.562 ns (1 allocation: 96 bytes)
```

After this PR:
```julia
julia> @btime g($f);
  97.467 ns (1 allocation: 32 bytes)

julia> @btime h($f);
  67.117 ns (0 allocations: 0 bytes)
```

With this, in-place read becomes allocation-free:

On master and using the latest tagged CFITSIO:
```julia
julia> hdu = f[1];

julia> @btime read!($hdu, $m);
  23.605 μs (3 allocations: 288 bytes)
```

After this PR:
```julia
julia> @btime read!($hdu, $m);
  23.086 μs (0 allocations: 0 bytes)
```

Even with non-inferred code and runtime dispatch, performance seems identical and there are no allocations:

```julia
julia> read1!(f, m) = read!(f[1], m);

julia> @btime read1!($f, $m);
  23.320 μs (0 allocations: 0 bytes)

julia> @code_warntype read1!(f, m)
Variables
  #self#::Core.Const(read1!)
  f::FITS
  m::Matrix{Int64}

Body::Array{Int64, N} where N
1 ─ %1 = Base.getindex(f, 1)::HDU
│   %2 = Main.read!(%1, m)::Array{Int64, N} where N
└──      return %2
```

One may of course help with the inference if the `eltype` and `ndim` is known:

```julia
julia> read1!(f, m) = read!(f[1]::ImageHDU{Int,2}, m);

julia> @code_warntype read1!(f, m)
Variables
  #self#::Core.Const(read1!)
  f::FITS
  m::Matrix{Int64}

Body::Matrix{Int64}
1 ─ %1 = Base.getindex(f, 1)::HDU
│   %2 = Core.apply_type(Main.ImageHDU, Main.Int, 2)::Core.Const(ImageHDU{Int64, 2})
│   %3 = Core.typeassert(%1, %2)::ImageHDU{Int64, 2}
│   %4 = Main.read!(%3, m)::Matrix{Int64}
└──      return %4

julia> @btime read1!($f, $m);
  23.328 μs (0 allocations: 0 bytes)
```