### PR TITLE
relax types of arguments to read

### DIFF
--- a/src/image.jl
+++ b/src/image.jl
@@ -176,7 +176,7 @@ end
 # _checkbounds methods copied from Julia v0.4 Base.
 _checkbounds(sz, i::Integer) = 1 <= i <= sz
 _checkbounds(sz, i::Colon) = true
-_checkbounds(sz, r::AbstractRange{Int}) =
+_checkbounds(sz, r::AbstractRange{<:Integer}) =
     (isempty(r) || (minimum(r) >= 1 && maximum(r) <= sz))
 
 # helper functions for constructing cfitsio indexing vectors in read(hdu, ...)

--- a/src/image.jl
+++ b/src/image.jl
@@ -202,7 +202,7 @@ _index_shape_dim(sz, dim, r::AbstractRange) = (length(r),)
     tuple(length(r), _index_shape_dim(sz, dim+1, I...)...)
 
 # Read a subset of an ImageHDU
-function read_internal(hdu::ImageHDU, I::Union{AbstractRange{Int}, Integer, Colon}...)
+function read_internal(hdu::ImageHDU, I::Union{AbstractRange{<:Integer}, Integer, Colon}...)
 
     # check number of indices and bounds. Note that number of indices and
     # array dimension must match, unlike in Arrays. Array-like behavior could
@@ -232,7 +232,7 @@ function read_internal(hdu::ImageHDU, I::Union{AbstractRange{Int}, Integer, Colo
 end
 
 function read_internal!(hdu::ImageHDU{T}, array::StridedArray{T},
-    I::Union{AbstractRange{Int}, Integer, Colon}...) where T
+    I::Union{AbstractRange{<:Integer}, Integer, Colon}...) where T
 
     if !iscontiguous(array)
         throw(ArgumentError("the output array needs to be contiguous"))
@@ -268,13 +268,13 @@ function read_internal!(hdu::ImageHDU{T}, array::StridedArray{T},
 end
 
 # general method and version that returns a single value rather than 0-d array
-read(hdu::ImageHDU, I::Union{AbstractRange{Int}, Int, Colon}...) =
+read(hdu::ImageHDU, I::Union{AbstractRange{<:Integer}, Integer, Colon}...) =
     read_internal(hdu, I...)
-read(hdu::ImageHDU, I::Int...) = read_internal(hdu, I...)[1]
+read(hdu::ImageHDU, I::Integer...) = read_internal(hdu, I...)[1]
 
-read!(hdu::ImageHDU{T}, array::StridedArray{T}, I::Union{AbstractRange{Int}, Int, Colon}...) where T<:Real =
+read!(hdu::ImageHDU{T}, array::StridedArray{T}, I::Union{AbstractRange{<:Integer}, Integer, Colon}...) where T<:Real =
     read_internal!(hdu, array, I...)
-read!(hdu::ImageHDU{T}, array::StridedArray{T}, I::Int...) where T<:Real = read_internal!(hdu, array, I...)[1]
+read!(hdu::ImageHDU{T}, array::StridedArray{T}, I::Integer...) where T<:Real = read_internal!(hdu, array, I...)[1]
 
 """
     fitswrite(filename::AbstractString, data; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -401,6 +401,7 @@ end
             FITS(filename, "w") do f
                 write(f, ones(2,2))
                 @test read(f[1], big(1), Int8(1)) == read(f[1], 1, 1)
+                @test read(f[1], big(1), Int8(1):Int8(2)) == read(f[1], 1, 1:2)
                 @test read(f[1], :, Int8(1)) == read(f[1], :, 1)
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -293,10 +293,10 @@ end
                 a = FITS(fname,"r") do f
                     read(f[1])
                 end
-                
+
                 b = reinterpret(T,arr)
                 @test b == a
-                
+
                 c = FITS(fname,"r") do f
                     reinterpret(Complex{T}, read(f[1]))
                 end
@@ -374,7 +374,7 @@ end
 
     @testset "fitsread" begin
         a = ones(3,3)
-        
+
         tempnamefits() do fname
             FITS(fname, "w") do f
                 write(f, a)
@@ -395,13 +395,23 @@ end
             end
         end
     end
+
+    @testset "non-Int integer indices" begin
+        tempnamefits() do filename
+            FITS(filename, "w") do f
+                write(f, ones(2,2))
+                @test read(f[1], big(1), Int8(1)) == read(f[1], 1, 1)
+                @test read(f[1], :, Int8(1)) == read(f[1], :, 1)
+            end
+        end
+    end
 end
 
 @testset "Write data to an existing image HDU" begin
     @testset "Overwrite an image" begin
         # Create a file with two images
         tempnamefits() do fname
-            
+
             FITS(fname, "w") do f
                 write(f, [[1 2 3]; [4 5 6]])
                 write(f, [[7 8 9]; [17 52 10]])


### PR DESCRIPTION
Accept `Integer` indices (other than `Int`) in `read`, so now these work:

```julia
julia> filename = tempname();

julia> FITSIO.fitswrite(filename, collect(reshape(1:100, 10, 10)));

julia> f = FITS(filename, "r");

julia> read(f[1], Int8(1):Int8(2), :)
2×10 Matrix{Int64}:
 1  11  21  31  41  51  61  71  81  91
 2  12  22  32  42  52  62  72  82  92

julia> read(f[1], Int8(1):Int8(2), big(3))
2-element Vector{Int64}:
 21
 22
```