### PR TITLE
write data of any eltype to an existing hdu

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FITSIO"
 uuid = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
-version = "0.16.8"
+version = "0.16.9"
 
 [deps]
 CFITSIO = "3b1b4be9-1499-4b22-8d78-7db3344d1961"

--- a/src/image.jl
+++ b/src/image.jl
@@ -369,7 +369,7 @@ end
 Write data to an existing image HDU.
 The data to be written out must be stored contiguously in memory.
 """
-function write(hdu::ImageHDU{T}, data::StridedArray{T}) where T<:Real
+function write(hdu::ImageHDU, data::StridedArray{<:Real})
 
     if !iscontiguous(data)
         throw(ArgumentError("data to be written out needs to be contiguous"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -456,6 +456,16 @@ end
         end
     end
 
+    @testset "write with different eltype" begin
+        tempnamefits() do fname
+            FITS(fname, "w") do f
+                write(f, ones(2,2)) # create an image with eltype Float64
+                write(f[1], ones(Int, 2, 2) .* 2) # write Int data to the same HDU
+                @test read(f[1]) == ones(2,2) .* 2 # check that data is written correctly
+            end
+        end
+    end
+
     @testset "fitswrite" begin
         tempnamefits() do fname
             a = ones(3,3)


### PR DESCRIPTION
write an array to an existing `hdu` even if the `eltype`s don't match. The data is internally converted by cfitsio to the correct eltype.