### PR TITLE
update hdu ext after deletion

### DIFF
--- a/src/fits.jl
+++ b/src/fits.jl
@@ -143,6 +143,10 @@ function deleteat!(f::FITS, i::Integer)
     f
 end
 
+isdeleted(hdu) = hdu.ext == -1
+assert_exists(hdu) = isdeleted(hdu) && error("HDU doesn't exist, it has been deleted previously")
+assert_open(hdu) = assert_exists(hdu) && fits_assert_open(hdu.fitsfile)
+
 """
     close(f::FITS)
 

--- a/src/header.jl
+++ b/src/header.jl
@@ -229,14 +229,14 @@ Same as above but FITS card is specified by its position and returns a 3
 element tuple where `keyname` is the keyword name (a string).
 """
 function read_key(hdu::HDU, key::Integer)
-    fits_assert_open(hdu.fitsfile)
+    assert_open(hdu)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
     keyout, value, comment = fits_read_keyn(hdu.fitsfile, key)
     keyout, parse_header_val(value), comment
 end
 
 function read_key(hdu::HDU, key::String)
-    fits_assert_open(hdu.fitsfile)
+    assert_open(hdu)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
     value, comment = fits_read_keyword(hdu.fitsfile, key)
     parse_header_val(value), comment
@@ -257,7 +257,7 @@ end of the header.
 function write_key(hdu::HDU, key::String,
                    value::Union{String, Bool, Integer, AbstractFloat, Nothing},
                    comment::Union{String, Ptr{Cvoid}}=C_NULL)
-    fits_assert_open(hdu.fitsfile)
+    assert_open(hdu)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
     fits_update_key(hdu.fitsfile, key, value, comment)
 end
@@ -266,7 +266,7 @@ end
 """
     read_header(filename::AbstractString, hduindex = 1) -> FITSHeader
 
-Convenience function to read the entire header corresponding to the HDU at index `hduindex` contained 
+Convenience function to read the entire header corresponding to the HDU at index `hduindex` contained
 in the FITS file named `filename`. Functionally `read_header(filename, hduindex)` is equivalent to
 
 ```julia
@@ -292,7 +292,7 @@ If the value cannot be parsed according to the FITS standard, the value is
 stored as the raw unparsed `String`.
 """
 function read_header(hdu::HDU)
-    fits_assert_open(hdu.fitsfile)
+    assert_open(hdu)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
 
     # Below, we use a direct call to ffgkyn so that we can keep reusing the
@@ -327,7 +327,7 @@ end
 Read the entire header from the given HDU as a single string.
 """
 function read_header(hdu::HDU, ::Type{String})
-    fits_assert_open(hdu.fitsfile)
+    assert_open(hdu)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
     fits_hdr2str(hdu.fitsfile)
 end

--- a/src/image.jl
+++ b/src/image.jl
@@ -3,8 +3,8 @@
 # Display the image datatype and dimensions
 function show(io::IO, hdu::ImageHDU)
     fits_assert_open(hdu.fitsfile)
-    if hdu.ext == -1
-        print(io, "HDU deleted")
+    if isdeleted(hdu)
+        print(io, "Deleted HDU")
         return
     end
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
@@ -46,7 +46,7 @@ Get image dimensions (or `i`th dimension), without reading the image
 into memory.
 """
 function size(hdu::ImageHDU{<:Any,N}) where N
-    fits_assert_open(hdu.fitsfile)
+    assert_open(hdu)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
     sz = fits_get_img_size(hdu.fitsfile, Val(N))
     NTuple{N,Int}(sz)
@@ -116,7 +116,7 @@ dropped in the returned array, while those specified by ranges will be retained.
     will have the sequence of axes flipped when read in using FITSIO.
 """
 function read(hdu::ImageHDU)
-    fits_assert_open(hdu.fitsfile)
+    assert_open(hdu)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
     data = Array{eltype(hdu)}(undef, size(hdu))
     fits_read_pix(hdu.fitsfile, data)
@@ -165,7 +165,7 @@ function read!(hdu::ImageHDU{<:Real,N}, array::StridedArray{<:Real,N}) where {N}
         throw(ArgumentError("the output array needs to be contiguous"))
     end
 
-    fits_assert_open(hdu.fitsfile)
+    assert_open(hdu)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
 
     if length(hdu) != length(array)
@@ -214,7 +214,7 @@ function read_internal(hdu::ImageHDU, I::Union{AbstractRange{<:Integer}, Integer
         throw(DimensionMismatch("number of indices must match dimensions"))
     end
 
-    fits_assert_open(hdu.fitsfile)
+    assert_open(hdu)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
 
     sz = size(hdu)
@@ -247,7 +247,7 @@ function read_internal!(hdu::ImageHDU, array::StridedArray,
         throw(DimensionMismatch("number of indices must match dimensions"))
     end
 
-    fits_assert_open(hdu.fitsfile)
+    assert_open(hdu)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
 
     sz = size(hdu)
@@ -377,7 +377,7 @@ function write(hdu::ImageHDU, data::StridedArray{<:Real})
         throw(ArgumentError("data to be written out needs to be contiguous"))
     end
 
-    fits_assert_open(hdu.fitsfile)
+    assert_open(hdu)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
 
     if fits_file_mode(hdu.fitsfile) == 0
@@ -433,7 +433,7 @@ copy_section(hdu, f, 1:200, 1:2:200)
 ```
 """
 function copy_section(hdu::ImageHDU, dest::FITS, r::AbstractRange{Int}...)
-    fits_assert_open(hdu.fitsfile)
+    assert_open(hdu)
     fits_assert_open(dest.fitsfile)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
     fits_copy_image_section(hdu.fitsfile, dest.fitsfile,

--- a/src/table.jl
+++ b/src/table.jl
@@ -161,7 +161,7 @@ function fits_read_table_header!(hdu::ASCIITableHDU, ncols, nrows,
 end
 
 function columns_names_tforms(hdu::Union{ASCIITableHDU,TableHDU})
-    fits_assert_open(hdu.fitsfile)
+    assert_open(hdu)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
     ncols = fits_get_num_cols(hdu.fitsfile)
 
@@ -188,6 +188,10 @@ Return the names of columns in a table HDU.
 colnames(hdu::Union{ASCIITableHDU,TableHDU}) = columns_names_tforms(hdu)[1]
 
 function show(io::IO, hdu::TableHDU)
+    if isdeleted(hdu)
+        print(io, "Deleted HDU")
+        return
+    end
     colnames, coltforms, ncols, nrows = columns_names_tforms(hdu)
     # get some more information for all the columns
     coltypes    = Vector{String}(undef, ncols)
@@ -219,6 +223,10 @@ function show(io::IO, hdu::TableHDU)
 end
 
 function show(io::IO, hdu::ASCIITableHDU)
+    if isdeleted(hdu)
+        print(io, "Deleted HDU")
+        return
+    end
     colnames, coltforms, ncols, nrows = columns_names_tforms(hdu)
     # Get additional info
     coltypes = Vector{String}(undef, ncols)
@@ -450,7 +458,7 @@ end
 
 # Read a table column
 function read(hdu::ASCIITableHDU, colname::String; case_sensitive::Bool=true)
-    fits_assert_open(hdu.fitsfile)
+    assert_open(hdu)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
 
     nrows = fits_get_num_rows(hdu.fitsfile)
@@ -501,12 +509,12 @@ considered case sensitive.
 
 !!! note "Array order"
 
-    Julia arrays are column-major (like Fortran), not row-major (like C 
-    and numpy), so elements of multi-dimensional columns will be the 
+    Julia arrays are column-major (like Fortran), not row-major (like C
+    and numpy), so elements of multi-dimensional columns will be the
     transpose of what you get with astropy.
 """
 function read(hdu::TableHDU, colname::String; case_sensitive::Bool=true)
-    fits_assert_open(hdu.fitsfile)
+    assert_open(hdu)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
 
     nrows = fits_get_num_rows(hdu.fitsfile)
@@ -530,7 +538,7 @@ function read(hdu::TableHDU, colname::String; case_sensitive::Bool=true)
     else
         colnum = fits_get_colnum(hdu.fitsfile, colname, case_sensitive=case_sensitive)
     end
-    
+
 
     T, rowsize, isvariable = fits_get_col_info(hdu.fitsfile, colnum)
 
@@ -548,7 +556,7 @@ end
 #Tables.jl integration
 
 const EitherTableHDU = Union{TableHDU, ASCIITableHDU}
-Tables.istable(::Type{<:EitherTableHDU}) = true    
+Tables.istable(::Type{<:EitherTableHDU}) = true
 Tables.columnaccess(::Type{<:EitherTableHDU}) = true
 Tables.columns(t::EitherTableHDU) = t
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -418,7 +418,7 @@ end
                 hdu = f[2]
                 deleteat!(f, 2)
                 @test length(f) == 1
-                @test repr(hdu) == "HDU deleted"
+                @test repr(hdu) == "Deleted HDU"
 
                 # if the array is read in before deletion,
                 # test that the hdu is removed from the cache


### PR DESCRIPTION
Alter the ext of an ImageHDU if it is deleted, so that functions don't accidentally try to access the non-existent HDU in the file.

master
```julia
julia> f = FITS(tempname(), "w");

julia> write(f, [1]);

julia> write(f, ones(1,1)*2);

julia> hdu = f[2]
File: /tmp/jl_GKwZG1
HDU: 2
Mode: read-write
Type: Image
Datatype: Float64
Datasize: (1, 1)

julia> deleteat!(f, 2)
File: /tmp/jl_GKwZG1
Mode: "w" (read-write)
HDUs: Num  Name  Type   
      1          Image  

julia> hdu
Error showing value of type ImageHDU{Float64, 2}:
ERROR: CFITSIO has encountered an error. Error code 107: tried to move past end of file
```

This PR allows us to throw an informative error
```julia
julia> hdu
Deleted HDU

julia> read(hdu)
ERROR: HDU doesn't exist, it has been deleted previously
```

The `fits_assert_open`  calls are now replaced by `assert_open` which checks that the file is open as well as whether the hdu exists.