### PR TITLE
Adjust header output formatting for better compatibility

### DIFF
--- a/src/header.jl
+++ b/src/header.jl
@@ -52,7 +52,7 @@ try_parse_hdrval(::Type{T}, s::String) where {T<:Union{Int,Float64}} =
 
 # functions for displaying header values in show(io, header)
 hdrval_repr(v::Bool) = v ? "T" : "F"
-hdrval_repr(v::String) = @sprintf "'%s'" v
+hdrval_repr(v::String) = @sprintf "'%-8s'" v
 hdrval_repr(v::Union{AbstractFloat, Integer}) = string(v)
 
 """
@@ -417,6 +417,10 @@ function show(io::IO, hdr::FITSHeader)
             if hdr.values[i] === nothing
                 print(io, "                      ")
                 rc = 50  # remaining characters on line
+            elseif hdr.values[i] isa String
+                val = hdrval_repr(hdr.values[i])
+                @printf io "= %-20s" val
+                rc = length(val) <= 20 ? 50 : 70 - length(val)
             else
                 val = hdrval_repr(hdr.values[i])
                 @printf io "= %20s" val

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -680,7 +680,7 @@ end
 FLTKEY  =                  1.0 / floating point keyword
 INTKEY  =                    1
 BOOLKEY =                    T / boolean keyword
-STRKEY  =       'string value' / string value
+STRKEY  = 'string value'       / string value
 COMMENT this is a comment
 HISTORY this is a history"""
 


### PR DESCRIPTION
In working on https://github.com/JuliaAstro/AstroImages.jl/issues/29, I found that for some images WCSLib could parse the headers in some FITS files just fine, but loading the headers with FITSIO and then calling `string` created headers that WCSLib could not read.

Doing a before and after diff, I found there were some minor differences in how string values are formatted.

This PR changes the formatting so that WCS.jl and WCSLib can read headers loaded by FITSIO from more images.

Before:
```
OBJECT  =                  ' ' / Name of the object observed
DATE    = '2009-09-03T04:30:56' / Date FITS file was generated
IRAF-TLM= '00:30:56 (03/09/2009)' / Time of last modification
EQUINOX =               2000.0 / Mean equinox
RADECSYS=               'ICRS' / Astrometric system
CTYPE1  =           'GLON-CAR' / WCS projection type for this axis
CUNIT1  =                'deg' / Axis unit
CRPIX1  =       1800.950026799 / Reference pixel on this axis
CD1_1   =   -0.099999998509884 / Linear projection matrix
CTYPE2  =           'GLAT-CAR' / WCS projection type for this axis
CUNIT2  =                'deg' / Axis unit
```

After:
```
OBJECT  = '        '           / Name of the object observed
DATE    = '2009-09-03T04:30:56' / Date FITS file was generated
IRAF-TLM= '00:30:56 (03/09/2009)' / Time of last modification
EQUINOX =               2000.0 / Mean equinox
RADECSYS= 'ICRS    '           / Astrometric system
CTYPE1  = 'GLON-CAR'           / WCS projection type for this axis
CUNIT1  = 'deg     '           / Axis unit
CRPIX1  =       1800.950026799 / Reference pixel on this axis
CD1_1   =   -0.099999998509884 / Linear projection matrix
CTYPE2  = 'GLAT-CAR'           / WCS projection type for this axis
CUNIT2  = 'deg     '           / Axis unit
```

Original (loaded in DS9):
```
OBJECT  = '        '           / Name of the object observed                    
DATE    = '2009-09-03T04:30:56' / Date FITS file was generated                  
IRAF-TLM= '00:30:56 (03/09/2009)' / Time of last modification                   
EQUINOX =      2.000000000E+03 / Mean equinox                                   
RADECSYS= 'ICRS    '           / Astrometric system                             
CTYPE1  = 'GLON-CAR'           / WCS projection type for this axis              
CUNIT1  = 'deg     '           / Axis unit                                      
CRPIX1  =       1800.950026799 / Reference pixel on this axis                   
CD1_1   =   -0.099999998509884 / Linear projection matrix                       
CTYPE2  = 'GLAT-CAR'           / WCS projection type for this axis              
CUNIT2  = 'deg     '           / Axis unit  
```

As you can see, string values are now left aligned and padded to  8 characters.
