### PR TITLE
Deletefix

### DIFF
--- a/src/header.jl
+++ b/src/header.jl
@@ -407,7 +407,7 @@ function delete!(hdr::FITSHeader, key::String)
 
 
     # Then re-create the map array
-    map = Dict(zip(hdr.keys, 1:length(hdr.keys)))
+    hdr.map = Dict(zip(hdr.keys, 1:length(hdr.keys)))
 
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -750,6 +750,14 @@ HISTORY this is a history"""
             
             @test_throws KeyError delete!(dhdr, "aaabbbbccccdddd")
 
+            
+            # Test multiple deletes
+            dhdr = deepcopy(inhdr)
+            delete!(dhdr, "FLTKEY")
+            delete!(dhdr, "INTKEY")
+            @test !haskey(dhdr, "FLTKEY") & !haskey(dhdr, "INTKEY")
+
+            
         end
         
         hdr = FITS(fname, "r") do f


### PR DESCRIPTION
There is a bug in header.jl in the delete! function where the map was not updated in the FITSHeader which could cause problems when multiple keys are deleted in a header. This fixes that and also adds a test in runtests.jl to verify that deletion of two keys in sequence works.