### PR TITLE
Add missing data type (UInt64/Culonglong)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FITSIO"
 uuid = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
-version = "0.17.1"
+version = "0.17.2"
 
 [deps]
 CFITSIO = "3b1b4be9-1499-4b22-8d78-7db3344d1961"

--- a/src/table.jl
+++ b/src/table.jl
@@ -22,6 +22,7 @@ for (T, tform, code) in ((UInt8,       'B',  11),
                          (Int16,       'I',  21),
                          (UInt32,      'V',  40),
                          (Int32,       'J',  41),
+                         (UInt64,      'W',  80),
                          (Int64,       'K',  81),
                          (Float32,     'E',  42),
                          (Float64,     'D',  82),
@@ -31,7 +32,7 @@ for (T, tform, code) in ((UInt8,       'B',  11),
     CFITSIO_COLTYPE[code] = T
 end
 const FITSTableScalar = Union{UInt8, Int8, Bool, UInt16, Int16, UInt32,
-                              Int32, Int64, Float32, Float64, ComplexF32,
+                              Int32, UInt64, Int64, Float32, Float64, ComplexF32,
                               ComplexF64}
 
 # Helper function for reading information about a (binary) table column
@@ -383,7 +384,7 @@ appending the table extension to it. `data` should be a dictionary
 with String keys (giving the column names) and Array values
 (giving data to write to each column). The following types are
 supported in binary tables: `UInt8`, `Int8`, `UInt16`, `Int16`,
-`UInt32`, `Int32`, `Int64`, `Float32`, `Float64`, `Complex{Float32}`,
+`UInt32`, `Int32`, `UInt64`, `Int64`, `Float32`, `Float64`, `Complex{Float32}`,
 `Complex{Float64}`, `String`, `Bool`.
 
 Optional inputs:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -520,7 +520,7 @@ end
         FITS(fname, "w") do f
             ## Binary table
             indata = Dict{String, Array}()
-            for (i, T) in enumerate([UInt8, Int8, UInt16, Int16, UInt32, Int32, Int64,
+            for (i, T) in enumerate([UInt8, Int8, UInt16, Int16, UInt32, Int32, UInt64, Int64,
                                      Float32, Float64, ComplexF32, ComplexF64])
                 indata["col$i"] = T[1:20;]
             end


### PR DESCRIPTION
CFITSIO definitions for reference:
<https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/c_user/node20.html>

Example file to reproduce error:
<https://data.sdss.org/sas/dr18/spectro/sdss/redux/v5_13_2/spectra/lite/3650/spec-3650-55244-0001.fits>

MWE/MRE:
```julia
using FITSIO
fits = FITS("spec-3650-55244-0001.fits")
hdu = fits["SPALL"]
read(hdu, "SPECOBJID")
```

This pr with https://github.com/JuliaAstro/CFITSIO.jl/pull/22 will fix error(s) including:
* `KeyError: key 80 not found`
* `MethodError: no method matching cfitsio_typecode(::Type{UInt64})`

