### PR TITLE
Draft: address unsafe pointer operations (segfaults on nightly)

### DIFF
--- a/src/fits.jl
+++ b/src/fits.jl
@@ -163,3 +163,11 @@ function close(f::FITS)
     empty!(f.hdus)
     nothing
 end
+
+
+# Safe counterpart to `unsafe_string(pointer(buffer::Vector{UInt8}))`
+# that reads a null terminated Byte buffer as a string.
+function safe_string(x::Vector{UInt8})
+    i = findfirst(iszero, x)
+    return String(view(x,firstindex(x):i-1))
+end

--- a/src/header.jl
+++ b/src/header.jl
@@ -411,7 +411,7 @@ function show(io::IO, hdr::FITSHeader)
     n = length(hdr)
     for i=1:n
         if hdr.keys[i] == "COMMENT" || hdr.keys[i] == "HISTORY"
-                lastc = min(71, lastindex(hdr.comments[i]))
+                lastc = min(72, lastindex(hdr.comments[i]))
                 @printf io "%s %s" hdr.keys[i] hdr.comments[i][1:lastc]
                 print(io, " "^(72-lastc))
         else

--- a/src/header.jl
+++ b/src/header.jl
@@ -429,8 +429,6 @@ function show(io::IO, hdr::FITSHeader)
                 rc = length(val) <= 20 ? 50 : 70 - length(val)
             end
             if length(hdr.comments[i]) > 0
-                # We don't pad out comments after keywords with trailing whitespace 
-                # but we do for standalone comments above.
                 lastc = min(rc-3, lastindex(hdr.comments[i]))
                 @printf io " / %s" hdr.comments[i][1:lastc]
                 rc -= lastc + 3

--- a/src/header.jl
+++ b/src/header.jl
@@ -411,7 +411,9 @@ function show(io::IO, hdr::FITSHeader)
     n = length(hdr)
     for i=1:n
         if hdr.keys[i] == "COMMENT" || hdr.keys[i] == "HISTORY"
-            @printf io "%s %s" hdr.keys[i] hdr.comments[i][1:min(71, end)]
+                lastc = min(71, lastindex(hdr.comments[i]))
+                @printf io "%s %s" hdr.keys[i] hdr.comments[i][1:lastc]
+                print(io, " "^(72-lastc))
         else
             @printf io "%-8s" hdr.keys[i]
             if hdr.values[i] === nothing
@@ -426,12 +428,20 @@ function show(io::IO, hdr::FITSHeader)
                 @printf io "= %20s" val
                 rc = length(val) <= 20 ? 50 : 70 - length(val)
             end
-
             if length(hdr.comments[i]) > 0
-                @printf io " / %s" hdr.comments[i][1:min(rc-3, end)]
+                # We don't pad out comments after keywords with trailing whitespace 
+                # but we do for standalone comments above.
+                lastc = min(rc-3, lastindex(hdr.comments[i]))
+                @printf io " / %s" hdr.comments[i][1:lastc]
+                rc -= lastc + 3
             end
+            print(io, " "^rc)
         end
-        i != n && println(io)
+        if i == n
+            println(io, "\nEND"*(" "^77))
+        else  
+            println(io)
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -677,12 +677,14 @@ end
                                 "this is a history"])
 
             @test repr(inhdr) == """
-FLTKEY  =                  1.0 / floating point keyword
-INTKEY  =                    1
-BOOLKEY =                    T / boolean keyword
-STRKEY  = 'string value'       / string value
-COMMENT this is a comment
-HISTORY this is a history"""
+FLTKEY  =                  1.0 / floating point keyword                         
+INTKEY  =                    1                                                  
+BOOLKEY =                    T / boolean keyword                                
+STRKEY  = 'string value'       / string value                                   
+COMMENT this is a comment                                                       
+HISTORY this is a history                                                       
+END                                                                             
+"""
 
             inhdr["INTKEY"] = 2  # test setting by key
             inhdr[1] = 2.0  # test settting by index


### PR DESCRIPTION
These changes begin to address the unsafe operations used in this package.
Currently these just deal with the most obvious issues.
Repeatedly running tests on nightly reveal that there are still segfaults. I believe we are leaking pointers to C somewhere. This will also have to be addressed.


Note that tests are failing due to an unrelated issue with complex arrays that also impacts nightly.

Edit: there are some unrelated changes in the first three commits I will excise from this PR.