### PR TITLE
add a more convenient FITSHeader constructor

### DIFF
--- a/src/header.jl
+++ b/src/header.jl
@@ -6,6 +6,12 @@
 # Used here and in other files. Functions that operate on FITSFile
 # start with `fits_`.
 
+FITSIO.FITSHeader(cards::AbstractVector{<:NamedTuple}) = FITSHeader(
+    map(x -> x.key, cards),
+    map(x -> x.value, cards),
+    map(x -> x.comment, cards),
+)
+
 """
     try_parse_hdrval(T, s) -> x::Union{T,Nothing}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -675,6 +675,17 @@ end
                                 "string value",
                                 "this is a comment",
                                 "this is a history"])
+            inhdr2 = FITSHeader(map(NamedTuple{(:key,:value,:comment)}, [
+                "FLTKEY", 1.0, "floating point keyword",
+                "INTKEY", 1, "",
+                "BOOLKEY", true, "boolean keyword",
+                "STRKEY", "string value", "string value",
+                "COMMENT", nothing, "this is a comment",
+                "HISTORY", nothing, "this is a history"
+            ]))
+            @test inhdr.keys == inhdr2.keys
+            @test inhdr.values == inhdr2.values
+            @test inhdr.comments == inhdr2.comments
 
             @test repr(inhdr) == """
 FLTKEY  =                  1.0 / floating point keyword

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -676,12 +676,12 @@ end
                                 "this is a comment",
                                 "this is a history"])
             inhdr2 = FITSHeader(map(NamedTuple{(:key,:value,:comment)}, [
-                "FLTKEY", 1.0, "floating point keyword",
-                "INTKEY", 1, "",
-                "BOOLKEY", true, "boolean keyword",
-                "STRKEY", "string value", "string value",
-                "COMMENT", nothing, "this is a comment",
-                "HISTORY", nothing, "this is a history"
+                ("FLTKEY", 1.0, "floating point keyword",),
+                ("INTKEY", 1, "",),
+                ("BOOLKEY", true, "boolean keyword",),
+                ("STRKEY", "string value", "string value",),
+                ("COMMENT", nothing, "this is a comment",),
+                ("HISTORY", nothing, "this is a history",),
             ]))
             @test inhdr.keys == inhdr2.keys
             @test inhdr.values == inhdr2.values


### PR DESCRIPTION
It's more convenient to provide all three (keys + values + comments) as a single array than separately.