### PR TITLE
add "Proper memory safety with GC.@preserve"

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -48,4 +48,8 @@ FITSIO.colnames
 write(::FITS, ::Dict{String})
 write(::FITS, ::Vector{String}, ::Vector)
 read(::TableHDU, ::String)
+VarColHandler
+UnsupportedVarColHandler
+NumericVarColHandler
+StringVarColHandler
 ```

--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -12,7 +12,13 @@ export FITS,
        get_comment,
        set_comment!,
        copy_section,
-       default_header
+       default_header,
+       fits_read_var_col,
+       fits_write_var_col,
+       varcolhandler,
+       StringVarColHandler,
+       NumericVarColHandler,
+       UnsupportedVarColHandler
 
 import Base: getindex,
              setindex!,

--- a/src/header.jl
+++ b/src/header.jl
@@ -23,18 +23,31 @@ See also: [`parse_header_val`](@ref).
 
 """
 function try_parse_hdrval(::Type{Bool}, s::String)
-    GC.@preserve s begin
-        if length(s) == 1
-            if s[1] == 'T'
+    @static if VERSION < v"1.6"
+        # For Julia 1.3: Use direct string access without view
+        str = String(s)  # Ensure we have a proper String
+        if length(str) == 1
+            if str[1] == 'T'
                 return true
-            elseif s[1] == 'F'
+            elseif str[1] == 'F'
                 return false
             end
         end
         return nothing
+    else
+        # For Julia 1.6+: Use GC.@preserve with proper string handling
+        GC.@preserve s begin
+            if length(s) == 1
+                if s[1] == 'T'
+                    return true
+                elseif s[1] == 'F'
+                    return false
+                end
+            end
+            return nothing
+        end
     end
 end
-
 # Note that trailing whitespaces are not significant in FITS header
 # keywords, but *leading* whitespaces are, so "'    '" parses as " " (a
 # single space).  See CFITSIO manual section 4.5 for details.

--- a/src/table.jl
+++ b/src/table.jl
@@ -263,10 +263,22 @@ end
 Type traits for variable length column operations
 """
 abstract type VarColHandler end
-
 struct StringVarColHandler <: VarColHandler end
 struct NumericVarColHandler <: VarColHandler end
 struct UnsupportedVarColHandler <: VarColHandler end
+
+# Define varcolhandler function
+function varcolhandler(::Type{String})
+    StringVarColHandler()
+end
+
+function varcolhandler(::Type{Vector{T}}) where T <: Number
+    NumericVarColHandler()
+end
+
+function varcolhandler(::Type{T}) where T
+    UnsupportedVarColHandler()
+end
 
 # Type trait definitions
 varcolhandler(::Type{<:Vector{String}}) = StringVarColHandler()

--- a/src/table.jl
+++ b/src/table.jl
@@ -285,13 +285,36 @@ varcolhandler(::Type{<:Vector{String}}) = StringVarColHandler()
 varcolhandler(::Type{<:Vector{Vector{T}}} where T) = NumericVarColHandler()
 varcolhandler(::Type) = UnsupportedVarColHandler()
 
-"""
-Read a variable length column - main dispatch function
-"""
+
 function fits_read_var_col(f::FITSFile, colnum::Integer, data::T) where T
     fits_read_var_col(f, colnum, data, varcolhandler(T))
 end
+"""
+    fits_write_var_col(f::FITSFile, colnum::Integer, data)
+    fits_write_var_col(data)
 
+Write variable-length column data to a FITS file.
+
+# Arguments
+- `f::FITSFile`: The FITS file to write to
+- `colnum::Integer`: The column number (1-based)
+- `data`: The data to write. Can be:
+  * Vector{String} for string columns
+  * Vector{Vector{T}} where T<:Number for numeric columns
+
+# Examples
+```julia
+FITS("example.fits", "w") do f
+    # Write string column
+    data = ["short", "medium", "long string"]
+    fits_write_var_col(f, 1, data)
+
+    # Write numeric column
+    numbers = [[1.0, 2.0], [3.0, 4.0, 5.0], [6.0]]
+    fits_write_var_col(f, 2, numbers)
+end
+```
+"""
 # Read a variable length array column of numbers
 # (separate implementation from normal fits_read_col function because
 # the length of each vector must be determined for each row.)

--- a/src/table.jl
+++ b/src/table.jl
@@ -260,22 +260,33 @@ end
 # (separate implementation from normal fits_write_col function because
 #  we must make separate calls to `fits_write_col` for each row.)
 """
+    VarColHandler
+
 Abstract type for handling variable length column operations in FITS files.
 """
 abstract type VarColHandler end
 
+
 """
+    StringVarColHandler <: VarColHandler
+
 Handler for variable length string columns in FITS files.
+Used to handle reading and writing of variable-length string arrays.
 """
 struct StringVarColHandler <: VarColHandler end
 
 """
+    NumericVarColHandler <: VarColHandler
+
 Handler for variable length numeric columns in FITS files.
+Used to handle reading and writing of variable-length numeric arrays.
 """
 struct NumericVarColHandler <: VarColHandler end
-
 """
+    UnsupportedVarColHandler <: VarColHandler
+
 Handler for unsupported variable length column types in FITS files.
+Used to handle error cases for unsupported data types.
 """
 struct UnsupportedVarColHandler <: VarColHandler end
 
@@ -288,10 +299,19 @@ struct UnsupportedVarColHandler <: VarColHandler end
 
 Determine the appropriate variable column handler for a given type.
 
-Returns:
+# Returns
 - `StringVarColHandler` for String types
 - `NumericVarColHandler` for numeric vector types
 - `UnsupportedVarColHandler` for unsupported types
+
+# Examples
+```julia
+varcolhandler(String)                  # Returns StringVarColHandler()
+varcolhandler(Vector{Float64})         # Returns NumericVarColHandler()
+varcolhandler(Vector{String})          # Returns StringVarColHandler()
+varcolhandler(Vector{Vector{Float64}}) # Returns NumericVarColHandler()
+varcolhandler(Complex{Float64})        # Returns UnsupportedVarColHandler()
+```
 """
 function varcolhandler(::Type{String})
     StringVarColHandler()

--- a/src/table.jl
+++ b/src/table.jl
@@ -400,12 +400,9 @@ function write_internal(f::FITS, colnames::Vector{String},
     end
 
     GC.@preserve f colnames coldata begin
-        # Add metadata to header if it exists
+        # Add header if it exists
         local_header = if header isa FITSHeader
-            hdr_copy = deepcopy(header)
-            hdr_copy["CREATOR"] = "kashish2210"
-            hdr_copy["DATE"] = "2025-03-29 00:13:36"
-            hdr_copy
+            deepcopy(header)
         else
             nothing
         end
@@ -463,7 +460,7 @@ function write_internal(f::FITS, colnames::Vector{String},
             end
         end
 
-        # Write header with metadata
+        # Write header if exists
         if local_header !== nothing
             fits_write_header(f.fitsfile, local_header, true)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -400,13 +400,29 @@ end
         a = ones(3,3)
         tempnamefits() do fname
             FITS(fname, "w") do f
-                write(f, a, name="a")
-                @test read(f["a"]) == a
-                @test read(f[1])   == a
-                @test haskey(f, "a")
-                @test !haskey(f, "b")
-                @test haskey(f, 1)
-                @test !haskey(f, 2)
+                GC.@preserve a begin
+                    write(f, a, name="a")
+                    @static if VERSION < v"1.6"
+                        read_data = read(f[String("a")])
+                        @test read_data == a
+                        @test read(f[1]) == a
+                        key_a = String("a")
+                        key_b = String("b")
+                        GC.@preserve key_a key_b begin
+                            @test haskey(f, key_a)
+                            @test !haskey(f, key_b)
+                        end
+                    else
+                        GC.@preserve begin
+                            @test read(f["a"]) == a
+                            @test read(f[1]) == a
+                            @test haskey(f, "a")
+                            @test !haskey(f, "b")
+                        end
+                    end
+                    @test haskey(f, 1)
+                    @test !haskey(f, 2)
+                end
             end
         end
     end
@@ -661,32 +677,35 @@ end
 @testset "FITSHeader" begin
     tempnamefits() do fname
         FITS(fname, "w") do f
-
             # test that show() works on an empty file and that the beginning and end
             # arre what we expect.
-            s = repr(f)
+            s = GC.@preserve f repr(f)
             @test s[1:6] == "File: "
             @test s[end-7:end] == "No HDUs."
 
             @test_throws ErrorException FITSHeader(["KEY1"], [1, 2, 3], ["comment 1", "comment 2"])
 
-            inhdr = FITSHeader(["FLTKEY", "INTKEY", "BOOLKEY", "STRKEY", "COMMENT",
-                                "HISTORY"],
-                               [1.0, 1, true, "string value", nothing, nothing],
-                               ["floating point keyword",
-                                "",
-                                "boolean keyword",
-                                "string value",
-                                "this is a comment",
-                                "this is a history"])
-            inhdr2 = FITSHeader(map(NamedTuple{(:key,:value,:comment)}, [
-                ("FLTKEY", 1.0, "floating point keyword",),
-                ("INTKEY", 1, "",),
-                ("BOOLKEY", true, "boolean keyword",),
-                ("STRKEY", "string value", "string value",),
-                ("COMMENT", nothing, "this is a comment",),
-                ("HISTORY", nothing, "this is a history",),
-            ]))
+            inhdr = GC.@preserve begin
+                FITSHeader(["FLTKEY", "INTKEY", "BOOLKEY", "STRKEY", "COMMENT",
+                            "HISTORY"],
+                           [1.0, 1, true, "string value", nothing, nothing],
+                           ["floating point keyword",
+                            "",
+                            "boolean keyword",
+                            "string value",
+                            "this is a comment",
+                            "this is a history"])
+            end
+            inhdr2 = GC.@preserve begin
+                FITSHeader(map(NamedTuple{(:key,:value,:comment)}, [
+                    ("FLTKEY", 1.0, "floating point keyword",),
+                    ("INTKEY", 1, "",),
+                    ("BOOLKEY", true, "boolean keyword",),
+                    ("STRKEY", "string value", "string value",),
+                    ("COMMENT", nothing, "this is a comment",),
+                    ("HISTORY", nothing, "this is a history",),
+                ]))
+            end
             @test inhdr.keys == inhdr2.keys
             @test inhdr.values == inhdr2.values
             @test inhdr.comments == inhdr2.comments
@@ -699,104 +718,121 @@ STRKEY  = 'string value'       / string value
 COMMENT this is a comment
 HISTORY this is a history"""
 
-            inhdr["INTKEY"] = 2  # test setting by key
-            inhdr[1] = 2.0  # test settting by index
-            set_comment!(inhdr, "INTKEY", "integer keyword") # test setting a comment
-
-            # Test reading possibly missing keyword
-            @test_throws KeyError inhdr["BADKEY"]
-            @test getkey(inhdr, "BADKEY", nothing) === nothing
-            @test getkey(inhdr, "INTKEY", nothing) == "INTKEY"
-            @test get(inhdr, "BADKEY", nothing) === nothing
-            @test get(inhdr, "INTKEY", nothing) == inhdr["INTKEY"]
-            @test get(() -> nothing, inhdr, "BADKEY") == nothing
-            @test get(() -> nothing, inhdr, "INTKEY") == inhdr["INTKEY"]
-
-            indata = reshape(Float32[1:100;], 5, 20)
-            write(f, indata; header=inhdr)
-
-            # Write a second block.
-            inhdr2 = deepcopy(inhdr)
-            inhdr2["INTKEY"] = 3 # Set it to a different value.
-            write(f, indata; header=inhdr2)
-
-            outhdr = read_header(f[1])
-            @test outhdr["FLTKEY"] === 2.0
-            @test outhdr["INTKEY"] === 2
-            @test outhdr["BOOLKEY"] === true
-            @test outhdr["STRKEY"] == "string value"
-            @test get_comment(outhdr, 13) == "this is a comment"
-            @test get_comment(outhdr, 14) == "this is a history"
-            @test length(outhdr) == 14
-            @test haskey(outhdr, "FLTKEY")
-
-            # Read entire header as a single string
-            s = read_header(f[1], String)
-            @test s[1:9] == "SIMPLE  ="  # all headers should start with this.
-            @test length(s) == (9 + length(inhdr)) * 80  # 9 lines = 8 default + "END"
-
-            # Test to check that read_header gets the right block even after reading another.
-            s_reread = read_header(f[1])
-            s_reread = read_header(f[2])
-            s_reread = read_header(f[1], String)
-            @test s == s_reread
-
-            # update an existing keyword, and read it directly
-            write_key(f[1], "FLTKEY", 3.0)
-            @test read_key(f[1], 9) == ("FLTKEY", 3.0, "floating point keyword")
-            @test read_key(f[1], "FLTKEY") == (3.0, "floating point keyword")
-
-            # Test appending a keyword, then modifying a keyword of different
-            # values with write_key()
-            for value in [1.0, "string value", 42, false, nothing]
-                write_key(f[1], "NEWKEY", value, "new key comment")
-                @test read_key(f[1], "NEWKEY") == (value, "new key comment")
-                @test read_key(f[1], 15) == ("NEWKEY", value, "new key comment")
+            @static if VERSION < v"1.6"
+                GC.@preserve inhdr begin
+                    inhdr["INTKEY"] = Int64(2)  # test setting by key
+                    inhdr[1] = Float64(2.0)  # test settting by index
+                    set_comment!(inhdr, String("INTKEY"), "integer keyword")
+                end
+            else
+                inhdr["INTKEY"] = 2  # test setting by key
+                inhdr[1] = 2.0  # test settting by index
+                set_comment!(inhdr, "INTKEY", "integer keyword")
             end
 
-            # Test that show() works and that the beginning of output is what we expect.
-            @test repr(f)[1:6] == "File: "
+            # Test reading possibly missing keyword
+            GC.@preserve inhdr begin
+                @test_throws KeyError inhdr["BADKEY"]
+                @test getkey(inhdr, "BADKEY", nothing) === nothing
+                @test getkey(inhdr, "INTKEY", nothing) == "INTKEY"
+                @test get(inhdr, "BADKEY", nothing) === nothing
+                @test get(inhdr, "INTKEY", nothing) == inhdr["INTKEY"]
+                @test get(() -> nothing, inhdr, "BADKEY") == nothing
+                @test get(() -> nothing, inhdr, "INTKEY") == inhdr["INTKEY"]
+            end
+
+            indata = reshape(Float32[1:100;], 5, 20)
+            GC.@preserve indata inhdr begin
+                write(f, indata; header=inhdr)
+
+                # Write a second block.
+                inhdr2 = deepcopy(inhdr)
+                inhdr2["INTKEY"] = 3 # Set it to a different value.
+                write(f, indata; header=inhdr2)
+            end
+
+            GC.@preserve f begin
+                outhdr = read_header(f[1])
+                @test outhdr["FLTKEY"] === 2.0
+                @test outhdr["INTKEY"] === 2
+                @test outhdr["BOOLKEY"] === true
+                @test outhdr["STRKEY"] == "string value"
+                @test get_comment(outhdr, 13) == "this is a comment"
+                @test get_comment(outhdr, 14) == "this is a history"
+                @test length(outhdr) == 14
+                @test haskey(outhdr, "FLTKEY")
+
+                # Read entire header as a single string
+                s = read_header(f[1], String)
+                @test s[1:9] == "SIMPLE  ="  # all headers should start with this.
+                @test length(s) == (9 + length(inhdr)) * 80  # 9 lines = 8 default + "END"
+
+                # Test to check that read_header gets the right block even after reading another.
+                s_reread = read_header(f[1])
+                s_reread = read_header(f[2])
+                s_reread = read_header(f[1], String)
+                @test s == s_reread
+
+                # update an existing keyword, and read it directly
+                write_key(f[1], "FLTKEY", 3.0)
+                @test read_key(f[1], 9) == ("FLTKEY", 3.0, "floating point keyword")
+                @test read_key(f[1], "FLTKEY") == (3.0, "floating point keyword")
+
+                # Test appending a keyword, then modifying a keyword of different
+                # values with write_key()
+                for value in [1.0, "string value", 42, false, nothing]
+                    write_key(f[1], "NEWKEY", value, "new key comment")
+                    @test read_key(f[1], "NEWKEY") == (value, "new key comment")
+                    @test read_key(f[1], 15) == ("NEWKEY", value, "new key comment")
+                end
+
+                # Test that show() works and that the beginning of output is what we expect.
+                @test repr(f)[1:6] == "File: "
+            end
 
             # Test the deletion of a key and verify that deleting a
             # non-existing key throws an error here.
-            dhdr = deepcopy(inhdr)
-            delete!(dhdr, "FLTKEY")
-            @test !haskey(dhdr, "FLTKEY")
+            dhdr = GC.@preserve inhdr deepcopy(inhdr)
+            GC.@preserve dhdr begin
+                delete!(dhdr, "FLTKEY")
+                @test !haskey(dhdr, "FLTKEY")
 
-            @test_throws KeyError delete!(dhdr, "aaabbbbccccdddd")
+                @test_throws KeyError delete!(dhdr, "aaabbbbccccdddd")
 
-
-            # Test multiple deletes
-            dhdr = deepcopy(inhdr)
-            delete!(dhdr, "FLTKEY")
-            delete!(dhdr, "INTKEY")
-            @test !haskey(dhdr, "FLTKEY") & !haskey(dhdr, "INTKEY")
-
-
+                # Test multiple deletes
+                dhdr = deepcopy(inhdr)
+                delete!(dhdr, "FLTKEY")
+                delete!(dhdr, "INTKEY")
+                @test !haskey(dhdr, "FLTKEY") & !haskey(dhdr, "INTKEY")
+            end
         end
 
-        hdr = FITS(fname, "r") do f
+        hdr = GC.@preserve fname FITS(fname, "r") do f
             read_header(f[1])
         end
-        hdrfname = read_header(fname)
+        hdrfname = GC.@preserve fname read_header(fname)
         @test keys(hdr) == keys(hdrfname)
         @test values(hdr) == values(hdrfname)
-        for k in keys(hdr)
-            @test get_comment(hdr, k) == get_comment(hdrfname, k)
+        GC.@preserve hdr hdrfname begin
+            for k in keys(hdr)
+                @test get_comment(hdr, k) == get_comment(hdrfname, k)
+            end
         end
     end
 
     @testset "default_header" begin
         data = fill(Int16(2), 5, 6, 2)
-        hdr = default_header(data)
-        @test hdr isa FITSHeader
-        @test hdr["SIMPLE"] == true
-        @test hdr["BITPIX"] == 16
-        @test hdr["NAXIS"] == 3
-        @test hdr["NAXIS1"] == 2
-        @test hdr["NAXIS2"] == 6
-        @test hdr["NAXIS3"] == 5
-        @test hdr["EXTEND"] == true
+        GC.@preserve data begin
+            hdr = default_header(data)
+            @test hdr isa FITSHeader
+            @test hdr["SIMPLE"] == true
+            @test hdr["BITPIX"] == 16
+            @test hdr["NAXIS"] == 3
+            @test hdr["NAXIS1"] == 2
+            @test hdr["NAXIS2"] == 6
+            @test hdr["NAXIS3"] == 5
+            @test hdr["EXTEND"] == true
+        end
     end
 end
 
@@ -881,37 +917,54 @@ end
             strings, numbers, integers = create_test_data()
 
             FITS(fname, "w") do f
-                write(f, zeros(Float32, 1))  # Primary HDU
-                
-                # Test writing multiple variable length columns of different types together
-                data = Dict(
-                    "STRINGS" => strings,
-                    "NUMBERS" => numbers,
-                    "INTEGERS" => integers
-                )
-                write(f, data; varcols=["STRINGS", "NUMBERS", "INTEGERS"])
+                # Ensure primary HDU is created properly
+                GC.@preserve begin
+                    write(f, zeros(Float32, 1))  # Primary HDU
+                    
+                    # Test writing multiple variable length columns of different types together
+                    data = Dict(
+                        "STRINGS" => strings,
+                        "NUMBERS" => numbers,
+                        "INTEGERS" => integers
+                    )
+                    write(f, data; varcols=["STRINGS", "NUMBERS", "INTEGERS"])
+                end
             end
 
             FITS(fname, "r") do f
                 hdu = f[2]
                 
-                # Test reading and verifying mixed types
-                read_strings = read(hdu, "STRINGS")
-                read_numbers = read(hdu, "NUMBERS")
-                read_integers = read(hdu, "INTEGERS")
-                
-                # Verify data integrity across types
-                @test all(read_strings .== strings)
-                @test all(length.(read_numbers) .== length.(numbers))
-                @test all(length.(read_integers) .== length.(integers))
-                
-                # Verify content equality
-                for (orig, read) in zip(numbers, read_numbers)
-                    @test all(orig .== read)
-                end
-                
-                for (orig, read) in zip(integers, read_integers)
-                    @test all(orig .== read)
+                # Test reading and verifying mixed types with GC protection
+                GC.@preserve hdu begin
+                    read_strings = read(hdu, "STRINGS")
+                    read_numbers = read(hdu, "NUMBERS")
+                    read_integers = read(hdu, "INTEGERS")
+                    
+                    # Version-specific string comparison
+                    @static if VERSION < v"1.6"
+                        # Direct string comparison for older Julia
+                        @test all(String.(read_strings) .== String.(strings))
+                    else
+                        # Modern comparison
+                        @test all(read_strings .== strings)
+                    end
+                    
+                    # Verify numeric data
+                    @test all(length.(read_numbers) .== length.(numbers))
+                    @test all(length.(read_integers) .== length.(integers))
+                    
+                    # Verify content equality with GC protection
+                    for (orig, read) in zip(numbers, read_numbers)
+                        GC.@preserve orig read begin
+                            @test all(orig .== read)
+                        end
+                    end
+                    
+                    for (orig, read) in zip(integers, read_integers)
+                        GC.@preserve orig read begin
+                            @test all(orig .== read)
+                        end
+                    end
                 end
             end
         end
@@ -920,11 +973,13 @@ end
     @testset "Error Handling for Invalid Types" begin
         tempnamefits() do fname
             FITS(fname, "w") do f
-                write(f, zeros(Float32, 1))
-                
-                # Test deeply nested vector rejection
-                nested_data = Dict("NESTED" => [[[1,2], [3,4]]])
-                @test_throws ErrorException write(f, nested_data; varcols=["NESTED"])
+                GC.@preserve begin
+                    write(f, zeros(Float32, 1))
+                    
+                    # Test deeply nested vector rejection
+                    nested_data = Dict("NESTED" => [[[1,2], [3,4]]])
+                    @test_throws ErrorException write(f, nested_data; varcols=["NESTED"])
+                end
             end
         end
     end


### PR DESCRIPTION
# Add GC.@preserve and enhance table string operations for Julia nightly compatibility

## Description
This PR addresses the Julia nightly compatibility issues of this #196  highlighted in #194 by improving string handling in table operations and ensuring proper memory management. Key improvements include the addition of `GC.@preserve` blocks and a new `safe_table_string_convert` function.

## Changes

### 1. String Handling Improvements
Added new `safe_table_string_convert` function for safer string handling in table operations:
The below function was initiated in #196 I have updated a lit bit:)
```julia
function safe_table_string_convert(str::AbstractString)
    GC.@preserve str begin
        # Ensure string data remains valid during conversion
        converted = # string conversion logic
        return converted
    end
end
```
Implemented type traits pattern to prevent method overwriting:
  ```julia
  abstract type VarColHandler end
  struct StringVarColHandler <: VarColHandler end
  struct NumericVarColHandler <: VarColHandler end
  struct UnsupportedVarColHandler <: VarColHandler end