### PR TITLE
Avoid direct ccalls and call CFITSIO wrappers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Aqua = "0.5"
-CFITSIO = "1.3"
+CFITSIO = "1.5"
 Reexport = "0.2, 1.0"
 Tables = "1"
 julia = "1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Aqua = "0.5"
-CFITSIO = "1.5"
+CFITSIO = "1.6"
 Reexport = "0.2, 1.0"
 Tables = "1"
 julia = "1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Aqua = "0.5"
-CFITSIO = "1.6"
+CFITSIO = "1.6.1"
 Reexport = "0.2, 1.0"
 Tables = "1"
 julia = "1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FITSIO"
 uuid = "525bcba6-941b-5504-bd06-fd0dc1a4d2eb"
-version = "0.17.4"
+version = "0.17.5"
 
 [deps]
 CFITSIO = "3b1b4be9-1499-4b22-8d78-7db3344d1961"

--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -84,7 +84,8 @@ import CFITSIO: FITSFile,
                 fits_get_hdu_num,
                 fits_get_hdu_type,
                 fits_read_btblhdr,
-                fits_read_atblhdr
+                fits_read_atblhdr,
+                fits_create_tbl
 
 # There are a few direct `ccall`s to libcfitsio in this module. For this, we
 # need a few non-exported things from Libcfitsio: the shared library handle,

--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -82,7 +82,9 @@ import CFITSIO: FITSFile,
                 fits_open_memfile,
                 fits_movnam_hdu,
                 fits_get_hdu_num,
-                fits_get_hdu_type
+                fits_get_hdu_type,
+                fits_read_btblhdr,
+                fits_read_atblhdr
 
 # There are a few direct `ccall`s to libcfitsio in this module. For this, we
 # need a few non-exported things from Libcfitsio: the shared library handle,

--- a/src/header.jl
+++ b/src/header.jl
@@ -101,7 +101,8 @@ See also: [`try_parse_hdrval`](@ref).
 
 """
 function fits_try_read_keys(f::FITSFile, ::Type{T}, keys) where T
-    (; value, comment) = CFITSIO.fits_read_keyword_buffer()
+    buf = CFITSIO.fits_read_keyword_buffer()
+    value, comment = buf.value, buf.comment
     for key in keys
         try
             value_str, comment_str = fits_read_keyword(f, key; value=value, comment=comment)
@@ -308,7 +309,8 @@ function read_header(hdu::HDU)
     nkeys, morekeys = fits_get_hdrspace(f)
 
     # Initialize output arrays
-    (; keyname, value, comment) = CFITSIO.fits_read_keyn_buffer()
+    buf = CFITSIO.fits_read_keyn_buffer()
+    keyname, value, comment = buf.keyname, buf.value, buf.comment
     keys = Vector{String}(undef, nkeys)
     values = Vector{Any}(undef, nkeys)
     comments = Vector{String}(undef, nkeys)

--- a/src/table.jl
+++ b/src/table.jl
@@ -137,47 +137,29 @@ fits_tform(::Type{ASCIITableHDU}, A::Array) = error("only 1-d arrays supported: 
 table_type_code(::Type{ASCIITableHDU}) = Cint(1)
 table_type_code(::Type{TableHDU}) = Cint(2)
 
-function fits_read_table_header!(hdu::TableHDU, ncols, nrows,
-                                 colnames_in, coltforms_in, status)
-    # fits_read_btblhdrll (Can pass NULL for return fields not needed.)
-    ccall(("ffghbnll", libcfitsio), Cint,
-          (Ptr{Cvoid}, Cint,  # Inputs: fitsfile, maxdim
-           Ref{Int64}, Ptr{Cint}, Ptr{Ptr{UInt8}},  # nrows, tfields, ttype
-           Ptr{Ptr{UInt8}}, Ptr{Ptr{UInt8}}, Ptr{UInt8},  # tform,tunit,extname
-           Ptr{Clong}, Ref{Cint}),  # pcount, status
-          hdu.fitsfile.ptr, ncols, nrows, C_NULL, colnames_in, coltforms_in,
-          C_NULL, C_NULL, C_NULL, status)
+function fits_read_table_header(hdu::TableHDU, ncols)
+    res = fits_read_btblhdr(hdu.fitsfile, ncols,
+            tunit=nothing, extname=nothing)
+    nrows = res[1]
+    colnames = res[3]
+    coltforms = res[4]
+    return nrows, colnames, coltforms
 end
 
-function fits_read_table_header!(hdu::ASCIITableHDU, ncols, nrows,
-                                 colnames_in, coltforms_in, status)
-    # fits_read_atblhdrll (Can pass NULL for return fields not needed)
-    ccall(("ffghtbll", libcfitsio), Cint,
-          (Ptr{Cvoid}, Cint,  # Inputs: fitsfile, maxdim
-           Ptr{Int64}, Ref{Int64}, Ptr{Cint},  # rowlen, nrows, tfields
-           Ptr{Ptr{UInt8}}, Ptr{Clong}, Ptr{Ptr{UInt8}},  # ttype, tbcol, tform
-           Ptr{Ptr{UInt8}}, Ptr{UInt8}, Ref{Cint}),  # tunit, extname, status
-          hdu.fitsfile.ptr, ncols, C_NULL, nrows, C_NULL, colnames_in,
-          C_NULL, coltforms_in, C_NULL, C_NULL, status)
+function fits_read_table_header(hdu::ASCIITableHDU, ncols)
+    res = fits_read_atblhdr(hdu.fitsfile, ncols,
+            tunit=nothing, extname=nothing, tbcol=nothing)
+    nrows = res[2]
+    colnames = res[4]
+    coltforms = res[6]
+    return nrows, colnames, coltforms
 end
 
 function columns_names_tforms(hdu::Union{ASCIITableHDU,TableHDU})
     assert_open(hdu)
     fits_movabs_hdu(hdu.fitsfile, hdu.ext)
     ncols = fits_get_num_cols(hdu.fitsfile)
-
-    # allocate return arrays for column names & types
-    colnames_in  = [Vector{UInt8}(undef, 70) for i=1:ncols]
-    coltforms_in = [Vector{UInt8}(undef, 70) for i=1:ncols]
-    nrows = Ref{Int64}()
-    status = Ref{Cint}(0)
-
-    fits_read_table_header!(hdu, ncols, nrows, colnames_in, coltforms_in, status)
-    fits_assert_ok(status[])
-
-    # parse out results
-    colnames = [unsafe_string(pointer(item)) for item in colnames_in]
-    coltforms = [unsafe_string(pointer(item)) for item in coltforms_in]
+    nrows, colnames, coltforms = fits_read_table_header(hdu, ncols)
     return colnames, coltforms, ncols, nrows
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -576,6 +576,9 @@ end
             expected_type = Dict(Int16=>Int32, Int32=>Int32,
                                  Float32=>Float64, Float64=>Float64,
                                  String=>String)
+            codes = Dict("Int16" => "I7", "Int32" => "I12",
+                         "Float32" => "E26.17", "Float64" => "E26.17",
+                         "String" => "A10")
             colnames = FITSIO.colnames(f[3])
             for (colname, incol) in indata
                 outcol = read(f[3], colname)  # table is in extension 3
@@ -590,14 +593,14 @@ end
             # we sort the lines as the order of the columns is not guaranteed
             sort!(lines, by = x -> split(x, " ")[1])
             lines_tokens = split.(lines, " ", keepempty=false)
-            codes = Dict("Int16" => "I7", "Int32" => "I12",
-                         "Float32" => "E26.17", "Float64" => "E26.17",
-                         "String" => "A10")
-            @test lines_tokens[1] == ["col1", "Int32", codes["Int16"]]
-            @test lines_tokens[2] == ["col2", "Int32", codes["Int32"]]
-            @test lines_tokens[3] == ["col3", "Float64", codes["Float32"]]
-            @test lines_tokens[4] == ["col4", "Float64", codes["Float64"]]
-            @test lines_tokens[5] == ["col5", "String", codes["String"]]
+            function tokenvec(k, d)
+                el = eltype(d[k])
+                el_exp = expected_type[el]
+                [k, string(el_exp), codes[string(el)]]
+            end
+            for i in 1:5
+                @test lines_tokens[i] == tokenvec("col$i", indata)
+            end
 
             # test variations on AbstractDict (issue #177)
             ordered_indata = OrderedDict(indata)
@@ -620,18 +623,10 @@ end
             lines_tokens = split.(lines, " ", keepempty=false)
 
             keys_ord_vec = collect(keys(ordered_indata))
-            function tokenvec(i)
-                k = keys_ord_vec[i]
-                el = eltype(ordered_indata[k])
-                el_exp = expected_type[el]
-                [k, string(el_exp), codes[string(el)]]
-            end
             # check that the order is preserved
-            @test lines_tokens[1] == tokenvec(1)
-            @test lines_tokens[2] == tokenvec(2)
-            @test lines_tokens[3] == tokenvec(3)
-            @test lines_tokens[4] == tokenvec(4)
-            @test lines_tokens[5] == tokenvec(5)
+            for (i, k) in enumerate(keys_ord_vec)
+                @test lines_tokens[i] == tokenvec(k, ordered_indata)
+            end
         end
     end
     @testset "Tables.jl integration" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -598,7 +598,7 @@ end
                 el_exp = expected_type[el]
                 [k, string(el_exp), codes[string(el)]]
             end
-            for i in 1:5
+            for i in eachindex(lines_tokens)
                 @test lines_tokens[i] == tokenvec("col$i", indata)
             end
 


### PR DESCRIPTION
This PR tries to reduce unsafe operations by ensuring that we call CFITSIO wrappers instead of directly dealing with pointers.