### PR TITLE
Handle 0-dim images

### DIFF
--- a/src/image.jl
+++ b/src/image.jl
@@ -127,6 +127,7 @@ function read(hdu::ImageHDU)
     fits_read_pix(hdu.fitsfile, data)
     data
 end
+read(hdu::ImageHDU{<:Any,0}) = (assert_open(hdu); nothing)
 
 #= Inplace read
 This requires a contiguous array. Lacking a type to dispatch upon,
@@ -359,6 +360,8 @@ function write(f::FITS, data::StridedArray{<:Real};
     if f.mode == "r"
         throw(ArgumentError("FITS file has been opened in read-only mode"))
     end
+
+    ndims(data) == 0 && throw(ArgumentError("data must have at least one dimension"))
 
     fits_create_img(f.fitsfile, data)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -898,3 +898,14 @@ end
     using FITSIO.Libcfitsio
     Libcfitsio.libcfitsio_version() isa VersionNumber
 end
+
+@testset "0-dim arrays" begin
+    tempnamefits() do fname
+        FITS(fname, "w") do f
+            @test_throws ArgumentError write(f, fill(0.0, ()))
+            fits_create_empty_img(f.fitsfile)
+            CFITSIO.fits_flush_file(f.fitsfile)
+            @test isnothing(read(f[1]))
+        end
+    end
+end


### PR DESCRIPTION
CFITSIO interprets 0-dim arrays differently from Julia. In CFITSIO, a 0-dim array is empty, whereas in Julia, it has one element. Writing a 0-dim array to a fits file therefore fails, and reading one that has been written somehow leads to nonsensical results, as we deal with uninitialized memory.

In this PR, we improve the error message in `write`, and make `read` for a 0-dim image HDU return `nothing`. This matches the behavior of astropy, and is probably the only sensible answer.