### PR TITLE
String fields in FITS

### DIFF
--- a/src/FITSIO.jl
+++ b/src/FITSIO.jl
@@ -172,8 +172,8 @@ parameters.
 """
 mutable struct FITS
     fitsfile::FITSFile
-    filename::AbstractString
-    mode::AbstractString
+    filename::String
+    mode::String
     hdus::Dict{Int, HDU}
 
     # Hold on to memory if backed by a julia buffer
@@ -190,13 +190,13 @@ mutable struct FITS
                 (rm(filename, force = true); createfn(filename)) :
              error("invalid open mode: $mode"))
 
-        new(f, filename, mode, Dict{Int, HDU}(), FITSMemoryHandle(), nothing)
+        new(f, convert(String, filename), convert(String, mode), Dict{Int, HDU}(), FITSMemoryHandle(), nothing)
     end
 
     function FITS(data::Vector{UInt8}, mode::AbstractString="r", filename = "")
         @assert mode == "r"
         f, handle = fits_open_memfile(data, 0)
-        new(f, filename, mode, Dict{Int, HDU}(), handle, data)
+        new(f, convert(String, filename), convert(String, mode), Dict{Int, HDU}(), handle, data)
     end
 end
 


### PR DESCRIPTION
Using concrete fields here would help with type-stability elsewhere. I am unsure if the flexibility of using `AbstractString` fields is useful here.