### PR TITLE
Fix `summary` for closed file

### DIFF
--- a/src/fits.jl
+++ b/src/fits.jl
@@ -89,9 +89,12 @@ function show(io::IO, f::FITS)
 end
 
 function Base.summary(io::IO, f::FITS)
-    fits_assert_open(f.fitsfile)
-    nhdu = length(f)
-    print(io, "FITS with $(nhdu) HDU", nhdu == 1 ? "" : "s")
+    if f.fitsfile.ptr != C_NULL # may use `isopen(f)` once that is implemented
+        nhdu = length(f)
+        print(io, "FITS with ", nhdu, " HDU", nhdu == 1 ? "" : "s")
+    else
+        print(io, "Closed FITS file")
+    end
 end
 
 # Returns HDU object based on extension number

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,8 @@ end
         @test_throws Exception write(f, ones(2))
         d = f[1]
         @test_throws Exception write(d, ones(2))
+        close(f)
+        @test summary(f) == "Closed FITS file"
 
         fname2 = fname*"[12].fits"
         FITS(fname2, "w", extendedparser = false) do f


### PR DESCRIPTION
Currently, we assert that the file is open in `summary` before reading fields from it. However, this obviously fails for a closed file. In this PR, we add a branch for a closed file, and change the assert to a check.